### PR TITLE
Controllers should die if watchdog fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ ROS2 Hardware Interface and Description for the ADA Robot
 2. See here for a [brief guide to using RVIZ to interact with MoveIt](https://moveit.picknik.ai/humble/doc/tutorials/quickstart_in_rviz/quickstart_in_rviz_tutorial.html).
 
 ### Real
-1. Run `ros2 launch ada_moveit demo.launch.py` command from your ROS2 workspace.
+1. Run `ros2 launch ada_moveit demo.launch.py` command from your ROS2 workspace. If running for feeding specifically (i.e., where the watchdog dying kills the controllers) run `ros2 launch ada_moveit demo_feeding.launch.py`. Make sure the watchdog is running before you launch this node.
 
 ## Camera Calibration
 

--- a/ada_moveit/launch/demo_feeding.launch.py
+++ b/ada_moveit/launch/demo_feeding.launch.py
@@ -1,0 +1,49 @@
+from moveit_configs_utils import MoveItConfigsBuilder
+from launch import LaunchDescription
+from launch.actions import (
+ IncludeLaunchDescription,
+ Shutdown,
+)
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+
+from srdfdom.srdf import SRDF
+
+
+def generate_launch_description():
+    # MoveIt Config
+    moveit_config = MoveItConfigsBuilder("ada", package_name="ada_moveit").to_moveit_configs()
+
+    # Create the launch description and populate
+    ld = LaunchDescription()
+
+    # Add the default demo.launch.py
+    ld.add_action(
+     IncludeLaunchDescription(
+         PythonLaunchDescriptionSource(
+             str(moveit_config.package_path / "launch/demo.launch.py")
+         ),
+     )
+    )
+
+    # Add the watchdog listener node
+    watchdog_timeout = {"watchdog_timeout": ParameterValue(0.1, value_type=float)}
+    watchdog_check_hz = {"watchdog_check_hz": ParameterValue(60.0, value_type=float)}
+    ld.add_action(
+     Node(
+         package="ada_feeding",
+         executable="ada_watchdog_listener_node.py",
+         parameters=[
+             watchdog_timeout,
+             watchdog_check_hz
+         ],
+         remappings=[
+             ("~/watchdog", "/ada_watchdog/watchdog")
+         ],
+         on_exit=Shutdown(),
+     )
+    )
+
+    return ld

--- a/ada_moveit/launch/demo_feeding.launch.py
+++ b/ada_moveit/launch/demo_feeding.launch.py
@@ -31,13 +31,15 @@ def generate_launch_description():
     # Add the watchdog listener node
     watchdog_timeout = {"watchdog_timeout": ParameterValue(0.1, value_type=float)}
     watchdog_check_hz = {"watchdog_check_hz": ParameterValue(60.0, value_type=float)}
+    initial_wait_time_sec = {"initial_wait_time_sec": ParameterValue(2.0, value_type=float)}
     ld.add_action(
      Node(
-         package="ada_feeding",
-         executable="ada_watchdog_listener_node.py",
+         package="ada_watchdog_listener",
+         executable="ada_watchdog_listener_node",
          parameters=[
              watchdog_timeout,
-             watchdog_check_hz
+             watchdog_check_hz,
+             initial_wait_time_sec,
          ],
          remappings=[
              ("~/watchdog", "/ada_watchdog/watchdog")

--- a/ada_watchdog_listener/ada_watchdog_listener/__init__.py
+++ b/ada_watchdog_listener/ada_watchdog_listener/__init__.py
@@ -1,0 +1,7 @@
+"""
+This package contains the ADAWatchdogListener class and a node that kills itself
+when the watchdog fails. The latter is useful to shutdown an entire launchfile
+(e.g., the one that launched the controllers) if the watchdog fails.
+"""
+
+from .ada_watchdog_listener import ADAWatchdogListener

--- a/ada_watchdog_listener/ada_watchdog_listener/ada_watchdog_listener.py
+++ b/ada_watchdog_listener/ada_watchdog_listener/ada_watchdog_listener.py
@@ -129,6 +129,7 @@ class ADAWatchdogListener:
         watchdog_failed = False
         for status in msg.status:
             if status.level != DiagnosticStatus.OK:
+                self._node.get_logger().error(f"Watchdog failed: {status.message}", throttle_duration_sec=1)
                 watchdog_failed = True
                 break
         self.watchdog_failed = watchdog_failed
@@ -144,7 +145,6 @@ class ADAWatchdogListener:
         True if the watchdog is OK and has not timed out, else False.
         """
         if self.watchdog_failed:
-            self._node.get_logger().error("Watchdog failed!", throttle_duration_sec=1)
             return False
         if (
             self._node.get_clock().now() - self.last_watchdog_msg_time

--- a/ada_watchdog_listener/ada_watchdog_listener/ada_watchdog_listener.py
+++ b/ada_watchdog_listener/ada_watchdog_listener/ada_watchdog_listener.py
@@ -1,0 +1,176 @@
+"""
+This module defines the ADAWatchdogListener class, which listens to the watchdog
+topic and can be used in two ways:
+    A: Query the watchdog listener to determine if the watchdog is `ok()`.
+    B: Pass in a callback function to be called when the watchdog status changes.
+"""
+
+# Standard imports
+from typing import Callable, Optional
+
+# Third-party imports
+from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus
+from rcl_interfaces.msg import ParameterDescriptor, ParameterType
+from rclpy.duration import Duration
+from rclpy.node import Node
+from rclpy.time import Time
+
+
+# pylint: disable=too-few-public-methods
+# This class only needs one public method to check if the watchdog is ok.
+class ADAWatchdogListener:
+    """
+    The ADAWatchdogListener class listens to the watchdog topic and can be used
+    in two ways:
+        A: Query the watchdog listener to determine if the watchdog is `ok()`.
+        B: Pass in a callback function to be called when the watchdog status
+            changes.
+    """
+
+    # pylint: disable=too-many-instance-attributes
+    # One extra is fine in this case.
+
+    def __init__(self, node: Node, callback_fn: Optional[Callable] = None) -> None:
+        """
+        Initialize the watchdog listener.
+
+        Parameters
+        ----------
+        node: the ROS node that this watchdog listener is associated with.
+        callback_fn: If not None, this function will be called when the watchdog
+            status changes. The function should take in a single boolean argument
+            that is True if the watchdog is ok, else False.
+        """
+        # Store the node
+        self._node = node
+
+        # Read the watchdog_timeout_sec parameter
+        watchdog_timeout_sec = self._node.declare_parameter(
+            "watchdog_timeout_sec",
+            0.5,  # default value
+            ParameterDescriptor(
+                name="watchdog_timeout_sec",
+                type=ParameterType.PARAMETER_DOUBLE,
+                description=(
+                    "The maximum time (s) that the watchdog can go without "
+                    "publishing before the watchdog fails."
+                ),
+                read_only=True,
+            ),
+        )
+        self.watchdog_timeout_sec = Duration(seconds=watchdog_timeout_sec.value)
+
+        # Read the watchdog_check_hz parameter
+        watchdog_check_hz = self._node.declare_parameter(
+            "watchdog_check_hz",
+            60.0,  # default value
+            ParameterDescriptor(
+                name="watchdog_check_hz",
+                type=ParameterType.PARAMETER_DOUBLE,
+                description=(
+                    "The rate (Hz) at which to check the whether the watchdog has failed."
+                    "This parameter is only used if a callback function is passed to the"
+                    "watchdog listener."
+                ),
+                read_only=True,
+            ),
+        )
+
+        # Read the initial_wait_time_sec parameter
+        initial_wait_time_sec = self._node.declare_parameter(
+            "initial_wait_time_sec",
+            0.0,  # default value
+            ParameterDescriptor(
+                name="initial_wait_time_sec",
+                type=ParameterType.PARAMETER_DOUBLE,
+                description=(
+                    "Additional time to add to `watchdog_timeout_sec` for the first "
+                    "watchdog message only. This is because even after the watchdog "
+                    "subscriber is created, it takes some time to actually start "
+                    "receiving messages."
+                ),
+                read_only=True,
+            ),
+        )
+
+        # Subscribe to the watchdog topic
+        # Initializing `watchdog_failed` to False lets the node wait up to `watchdog_timeout_sec`
+        # sec to receive the first message
+        self.watchdog_failed = False
+        # Add a grace period of `initial_wait_time_sec` sec for receiving the
+        # first watchdog message
+        self.last_watchdog_msg_time = self._node.get_clock().now() + Duration(
+            seconds=initial_wait_time_sec.value
+        )
+        self.watchdog_sub = self._node.create_subscription(
+            DiagnosticArray,
+            "~/watchdog",
+            self.__watchdog_callback,
+            1,
+        )
+
+        # If a callback function is passed in, check the watchdog at the specified rate
+        if callback_fn is not None:
+            self.callback_fn = callback_fn
+            self._prev_status = None
+            timer_period = 1.0 / watchdog_check_hz.value
+            self.timer = self._node.create_timer(timer_period, self.__timer_callback)
+
+    def __watchdog_callback(self, msg: DiagnosticArray) -> None:
+        """
+        Callback function for the watchdog topic. This function checks if the
+        watchdog has failed (i.e., if any DiagnosticStatus has a level that is
+        not DiagnosticStatus.OK).
+
+        Parameters
+        ----------
+        msg: The watchdog message.
+        """
+        watchdog_failed = False
+        for status in msg.status:
+            if status.level != DiagnosticStatus.OK:
+                watchdog_failed = True
+                break
+        self.watchdog_failed = watchdog_failed
+
+        self.last_watchdog_msg_time = Time.from_msg(msg.header.stamp)
+
+    # pylint: disable=invalid-name
+    # This matches the corresponding method name in rclpy.
+    def ok(self) -> bool:
+        """
+        Returns
+        -------
+        True if the watchdog is OK and has not timed out, else False.
+        """
+        if self.watchdog_failed:
+            self._node.get_logger().error("Watchdog failed!", throttle_duration_sec=1)
+            return False
+        if (
+            self._node.get_clock().now() - self.last_watchdog_msg_time
+        ) > self.watchdog_timeout_sec:
+            self._node.get_logger().error(
+                "Did not receive a watchdog message for > "
+                f"{self.watchdog_timeout_sec.nanoseconds / 10.0**9} seconds!",
+                throttle_duration_sec=1,
+            )
+            return False
+        return True
+
+    def __timer_callback(self) -> None:
+        """
+        If the watchdog has failed, call the callback function.
+        """
+        # Get the watchdog status
+        curr_status = self.ok()
+
+        # Check if the watchdog status has changed since the last time this function was called
+        if self._prev_status is None or curr_status != self._prev_status:
+            # If it has, call the callback function
+            self._node.get_logger().debug(
+                f"Watchdog status (whether it is ok) changed to {curr_status}"
+            )
+            self.callback_fn(curr_status)
+
+        # Update the previous status
+        self._prev_status = curr_status

--- a/ada_watchdog_listener/ada_watchdog_listener/ada_watchdog_listener.py
+++ b/ada_watchdog_listener/ada_watchdog_listener/ada_watchdog_listener.py
@@ -129,7 +129,9 @@ class ADAWatchdogListener:
         watchdog_failed = False
         for status in msg.status:
             if status.level != DiagnosticStatus.OK:
-                self._node.get_logger().error(f"Watchdog failed: {status.message}", throttle_duration_sec=1)
+                self._node.get_logger().error(
+                    f"Watchdog failed: {status.message}", throttle_duration_sec=1
+                )
                 watchdog_failed = True
                 break
         self.watchdog_failed = watchdog_failed

--- a/ada_watchdog_listener/ada_watchdog_listener/ada_watchdog_listener_node.py
+++ b/ada_watchdog_listener/ada_watchdog_listener/ada_watchdog_listener_node.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+This module contains a node, ADAWatchdogListener, which listens to the
+watchdog topic and kills itself if the watchdog fails. This is useful
+because launchfiles allow us to perform an action when a node exits,
+so we can use a node like this to terminate the entire launchfile when
+the watchdog fails.
+"""
+
+# Standard imports
+import threading
+from typing import List
+
+# Third-party imports
+import rclpy
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.node import Node
+from std_srvs.srv import SetBool
+
+# Local imports
+from ada_watchdog_listener import ADAWatchdogListener
+
+
+class ADAWatchdogListenerNode(Node):
+    """
+    A ROS2 node that listens to the watchdog topic and kills itself
+    if the watchdog fails.
+    """
+
+    def __init__(self) -> None:
+        """
+        Initialize the node.
+        """
+        super().__init__("ada_watchdog_listener")
+
+        # Create a service to toggle this node on-and-off
+        self.toggle_service = self.create_service(
+            SetBool,
+            "~/toggle_watchdog_listener",
+            self.toggle_callback,
+        )
+        self.is_on = True
+        self.is_on_lock = threading.Lock()
+
+        # Create the watchdog listener
+        self.ada_watchdog_listener = ADAWatchdogListener(
+            self, callback_fn=self.watchdog_status_callback
+        )
+
+        self.get_logger().info("Initialized!")
+
+    def toggle_callback(self, request: SetBool.Request, response: SetBool.Response):
+        """
+        Callback for the toggle service.
+        """
+        response.success = False
+        response.message = f"Failed to set is_on to {request.data}"
+        with self.is_on_lock:
+            self.is_on = request.data
+            response.success = True
+            response.message = f"Successfully set is_on to {request.data}"
+            if request.data:
+                self.get_logger().info("Succesfully turned the watchdog listener on.")
+            else:
+                self.get_logger().warn(
+                    "WARNING: You have turned the watchdog listener off. "
+                    "This can be dangerous, because typically the launchfile "
+                    "that creates the controllers will terminate if this node "
+                    "dies, thereby terminating all robot motion. With this node "
+                    "off, there is no guard to stop robot motion if the watchdog "
+                    "fails."
+                )
+        return response
+
+    def watchdog_status_callback(self, new_status: bool) -> None:
+        """
+        Callback for when the watchdog's status changes. If this node `is_on`
+        and the watchdog status changes to false, kill this node.
+
+        Parameters
+        ----------
+        new_status: bool
+            The new status of the watchdog.
+        """
+        # If the watchdog failed
+        if not new_status:
+            # If the node is on, kill the node.
+            with self.is_on_lock:
+                is_on = self.is_on
+            if is_on:
+                self.get_logger().error("Watchdog failed. Killing node.")
+                self.destroy_node()
+                rclpy.shutdown()
+
+
+def main(args: List = None) -> None:
+    """
+    Create the ROS2 node to listen to the watchdog.
+    """
+    rclpy.init(args=args)
+
+    ada_watchdog_listener_node = ADAWatchdogListenerNode()
+    executor = MultiThreadedExecutor()
+    rclpy.spin(ada_watchdog_listener_node, executor=executor)
+
+
+if __name__ == "__main__":
+    main()

--- a/ada_watchdog_listener/package.xml
+++ b/ada_watchdog_listener/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ada_watchdog_listener</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="amaln@uw.edu">amalnanavati</maintainer>
+  <license>TODO: License declaration</license>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/ada_watchdog_listener/setup.cfg
+++ b/ada_watchdog_listener/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/ada_watchdog_listener
+[install]
+install_scripts=$base/lib/ada_watchdog_listener

--- a/ada_watchdog_listener/setup.py
+++ b/ada_watchdog_listener/setup.py
@@ -1,0 +1,25 @@
+from setuptools import setup
+
+package_name = "ada_watchdog_listener"
+
+setup(
+    name=package_name,
+    version="0.0.0",
+    packages=[package_name],
+    data_files=[
+        ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
+        ("share/" + package_name, ["package.xml"]),
+    ],
+    install_requires=["setuptools"],
+    zip_safe=True,
+    maintainer="Amal Nanavati",
+    maintainer_email="amaln@cs.washington.edu",
+    description="This package contains libraries and nodes related to listening to the output of a watchdog.",
+    license="BSD-3-Clause",
+    tests_require=["pytest"],
+    entry_points={
+        "console_scripts": [
+            "ada_watchdog_listener_node = ada_watchdog_listener.ada_watchdog_listener_node:main",
+        ],
+    },
+)

--- a/ada_watchdog_listener/test/test_copyright.py
+++ b/ada_watchdog_listener/test/test_copyright.py
@@ -1,0 +1,27 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_copyright.main import main
+import pytest
+
+
+# Remove the `skip` decorator once the source file(s) have a copyright header
+@pytest.mark.skip(
+    reason="No copyright header has been placed in the generated source file."
+)
+@pytest.mark.copyright
+@pytest.mark.linter
+def test_copyright():
+    rc = main(argv=[".", "test"])
+    assert rc == 0, "Found errors"

--- a/ada_watchdog_listener/test/test_flake8.py
+++ b/ada_watchdog_listener/test/test_flake8.py
@@ -1,0 +1,25 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_flake8.main import main_with_errors
+import pytest
+
+
+@pytest.mark.flake8
+@pytest.mark.linter
+def test_flake8():
+    rc, errors = main_with_errors(argv=[])
+    assert rc == 0, "Found %d code style errors / warnings:\n" % len(
+        errors
+    ) + "\n".join(errors)

--- a/ada_watchdog_listener/test/test_pep257.py
+++ b/ada_watchdog_listener/test/test_pep257.py
@@ -1,0 +1,23 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_pep257.main import main
+import pytest
+
+
+@pytest.mark.linter
+@pytest.mark.pep257
+def test_pep257():
+    rc = main(argv=[".", "test"])
+    assert rc == 0, "Found code style errors / warnings"


### PR DESCRIPTION
# Description

This PR adds a new launchfile, `demo_feeding.launch.py`, that launches all the same nodes as `demo.launch.py` but also launches a watchdog listener and completely terminates the launchfile if the watchdog fails.

# Testing

Pull the code from [ada_feeding#48](https://github.com/personalrobotics/ada_feeding/pull/48)

## Setup: Sim

1. Run the dummy FT sensor: `ros2 run ada_feeding dummy_ft_sensor.py`
2. Run the watchdog: `ros2 launch ada_feeding ada_feeding_launch.xml`
3. Launch MoveIt: `ros2 launch ada_moveit demo_feeding.launch.py sim:=mock`

## Setup: Real Robot

1. Run the FT sensor: `ros2 run forque_sensor_hardware forque_sensor_hardware —ros-args -p host:=xxx.xxx.x.xx`
    1. Re-tare the sensor: `ros2 service call /wireless_ft/set_bias std_srvs/srv/SetBool "{data: true}"`
2. Run the watchdog: `ros2 launch ada_feeding ada_feeding_launch.xml`
3. Launch MoveIt: `ros2 launch ada_moveit demo_feeding.launch.py`

## Tests
- Verify that `ada_watchdog_listener_node.py` works as expected:
    - [x] Run the dummy FT sensor, the ada_feeding launchfile, the listener node `ros2 run ada_watchdog_listener ada_watchdog_listener_node --ros-args --remap ada_watchdog_listener/watchdog:=ada_watchdog/watchdog`. Verify that the node stays alive.
    - [x] Kill the dummy FT sensor. Verify that the node dies.
    - [x] Re-start the dummy FT sensor and the listener node. Set the dummy FT sensor to be 0 variance in at least one dimension: `ros2 param set /dummy_ft_sensor std  '[0.1, 0.1, 0.0, 0.1, 0.1, 0.1]'`. Verify that the listener node dies.
    - [x] Re-start the dummy FT sensor and the listener node. Re-tare the F/T sensor `ros2 service call /wireless_ft/set_bias std_srvs/srv/SetBool "{data: true}"`. Verify that the listener node dies.
    - [x] Re-start the dummy FT sensor and the listener node and  turn the listener node off `ros2 service call /ada_watchdog_listener/toggle_watchdog_listener std_srvs/srv/SetBool "{data: false}"`. Re-tare the F/T sensor `ros2 service call /wireless_ft/set_bias std_srvs/srv/SetBool "{data: true}"`. Then, turn the listener node on. Verify that the listener node stays alive.

- Run the setup steps above. Then, turn off the watchdog listener, re-tare the FT sensor, and re-turn on the watchdog listener. Then: Call `ros2 action send_goal /MoveAbovePlate ada_feeding_msgs/action/MoveTo "{}" --feedback` and verify that it succeeds.
    - [x] Sim
    - [x] Real
- Do the above but terminate FT node while the robot is moving, verify that the MoveIt launchfile terminates within 0.1sec.
    - [x] Sim
    - [x] Real

# Notes / Discussion Points

1. The watchdog params and remapping for `create_action_servers.py` are defined in `ada_feeding`, whereas the same parameters/remapping are also defined in `demo_feeding.launch.py`. Are we okay with this?
2. **EDIT: This has now been addressed**. Note that the order of launches becomes important, because we first have to start the watchdog, then start MoveIt, and then populate the planning scene, whereas right now the watchdog and planning scene are launched together. I'll probably modify [ada_feeding#48](https://github.com/personalrobotics/ada_feeding/pull/48) to have the planning scene node wait until there is a subscriber on the topic, to address this.