### PR TITLE
Remove FixStart parts of the planning pipeline

### DIFF
--- a/ada_moveit/config/ompl_planning.yaml
+++ b/ada_moveit/config/ompl_planning.yaml
@@ -6,9 +6,6 @@ request_adapters: >-
     default_planner_request_adapters/AddTimeOptimalParameterization
     default_planner_request_adapters/ResolveConstraintFrames
     default_planner_request_adapters/FixWorkspaceBounds
-    default_planner_request_adapters/FixStartStateBounds
-    default_planner_request_adapters/FixStartStateCollision
-    default_planner_request_adapters/FixStartStatePathConstraints
 # Based on Kinova's parameters: https://github.com/Kinovarobotics/kinova-ros/blob/noetic-devel/kinova_moveit/robot_configs/j2n6s300_moveit_config/config/ompl_planning.yaml
 planner_configs:
   SBLkConfigDefault:


### PR DESCRIPTION
Currently, if the start configuarion is in an invalid state, MoveIt attempts a plan that fixes that. This results in plans that (a) ignore constraints we have set; and (b) look very strange, because they are effectively a combination of one non-constrained plan and another constrained plan.

This PR removes those parts of the planning pipeline.