### PR TITLE
Black formatting of all python files

### DIFF
--- a/ada_description/launch/view_ada.launch.py
+++ b/ada_description/launch/view_ada.launch.py
@@ -31,7 +31,12 @@
 import launch
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, Shutdown
-from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
+from launch.substitutions import (
+    Command,
+    FindExecutable,
+    LaunchConfiguration,
+    PathJoinSubstitution,
+)
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 from launch_ros.descriptions import ParameterValue
@@ -60,8 +65,7 @@ def generate_launch_description():
         DeclareLaunchArgument(
             "use_forque",
             default_value="false",
-            description="If the forque apparatus is being used.",            
-
+            description="If the forque apparatus is being used.",
         )
     )
 
@@ -75,13 +79,17 @@ def generate_launch_description():
         [
             PathJoinSubstitution([FindExecutable(name="xacro")]),
             " ",
-            PathJoinSubstitution([FindPackageShare(description_package), "urdf", description_file]),
+            PathJoinSubstitution(
+                [FindPackageShare(description_package), "urdf", description_file]
+            ),
             " ",
             "use_forque:=",
             use_forque,
         ]
     )
-    robot_description = {"robot_description": ParameterValue(robot_description_content, value_type=str)}
+    robot_description = {
+        "robot_description": ParameterValue(robot_description_content, value_type=str)
+    }
 
     joint_state_publisher_node = Node(
         package="joint_state_publisher_gui",
@@ -96,7 +104,6 @@ def generate_launch_description():
         on_exit=Shutdown(),
     )
 
-    
     rviz_config_file = PathJoinSubstitution(
         [FindPackageShare(description_package), "rviz", "view_robot.rviz"]
     )

--- a/ada_hardware/launch/ada_hardware.launch.py
+++ b/ada_hardware/launch/ada_hardware.launch.py
@@ -1,19 +1,19 @@
 # Copyright 2023 Personal Robotics Lab, University of Washington
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 #    * Redistributions of source code must retain the above copyright
 #      notice, this list of conditions and the following disclaimer.
-# 
+#
 #    * Redistributions in binary form must reproduce the above copyright
 #      notice, this list of conditions and the following disclaimer in the
 #      documentation and/or other materials provided with the distribution.
-# 
+#
 #    * Neither the name of the {copyright_holder} nor the names of its
 #      contributors may be used to endorse or promote products derived from
 #      this software without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -31,7 +31,12 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, RegisterEventHandler, Shutdown
 from launch.conditions import IfCondition
 from launch.event_handlers import OnProcessExit
-from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
+from launch.substitutions import (
+    Command,
+    FindExecutable,
+    LaunchConfiguration,
+    PathJoinSubstitution,
+)
 
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
@@ -104,7 +109,7 @@ def generate_launch_description():
     start_rviz = LaunchConfiguration("start_rviz")
 
     use_sim_time = True
-    if sim == 'none':
+    if sim == "none":
         use_sim_time = False
 
     # Get URDF via xacro
@@ -120,7 +125,9 @@ def generate_launch_description():
             sim,
         ]
     )
-    robot_description = {"robot_description": ParameterValue(robot_description_content, value_type=str)}
+    robot_description = {
+        "robot_description": ParameterValue(robot_description_content, value_type=str)
+    }
 
     robot_controllers = PathJoinSubstitution(
         [
@@ -136,7 +143,11 @@ def generate_launch_description():
     control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[robot_description, robot_controllers, {'use_sim_time': use_sim_time}],
+        parameters=[
+            robot_description,
+            robot_controllers,
+            {"use_sim_time": use_sim_time},
+        ],
         output="both",
         on_exit=Shutdown(),
     )
@@ -144,7 +155,7 @@ def generate_launch_description():
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="both",
-        parameters=[robot_description, {'use_sim_time': use_sim_time}],
+        parameters=[robot_description, {"use_sim_time": use_sim_time}],
     )
     rviz_node = Node(
         package="rviz2",
@@ -153,13 +164,17 @@ def generate_launch_description():
         output="log",
         arguments=["-d", rviz_config_file],
         condition=IfCondition(start_rviz),
-        parameters=[{'use_sim_time': use_sim_time}]
+        parameters=[{"use_sim_time": use_sim_time}],
     )
 
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
+        arguments=[
+            "joint_state_broadcaster",
+            "--controller-manager",
+            "/controller_manager",
+        ],
     )
 
     robot_controller_spawner = Node(
@@ -177,10 +192,12 @@ def generate_launch_description():
     )
 
     # Delay start of robot_controller after `joint_state_broadcaster`
-    delay_robot_controller_spawner_after_joint_state_broadcaster_spawner = RegisterEventHandler(
-        event_handler=OnProcessExit(
-            target_action=joint_state_broadcaster_spawner,
-            on_exit=[robot_controller_spawner],
+    delay_robot_controller_spawner_after_joint_state_broadcaster_spawner = (
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=joint_state_broadcaster_spawner,
+                on_exit=[robot_controller_spawner],
+            )
         )
     )
 

--- a/ada_imu/ada_imu/imu_jointstate_publisher.py
+++ b/ada_imu/ada_imu/imu_jointstate_publisher.py
@@ -22,6 +22,7 @@ class IMUJointstatePublisher(Node):
     velocity of the wheelchair's tilt, and publishes the values in a
     JointState message to /joint_states.
     """
+
     # pylint: disable=too-many-instance-attributes
     # Smoothing and calibration vectors require more variables than pylint allows
     def __init__(self):
@@ -49,7 +50,7 @@ class IMUJointstatePublisher(Node):
 
         self.init_serial()
         self.init_vectors()
-        #declare changing variables
+        # declare changing variables
         self.prev_smoothed_position = 0.0
         self.prev_angle = 0.0
         self.prev_smoothed_velocity = 0.0
@@ -221,7 +222,7 @@ class IMUJointstatePublisher(Node):
 
         Parameters
         ----------
-        smoothing_factor: floating point variable between 0 and 1, determines how much 
+        smoothing_factor: floating point variable between 0 and 1, determines how much
         smoothing is applied
         current_datapoint: the most recent datapoint that the average is being applied to
         previous_average: the output of the smoothing function on the previous datapoint
@@ -236,7 +237,7 @@ class IMUJointstatePublisher(Node):
 
 
 def main(args=None):
-    """ Spins imu jointstate publisher node """
+    """Spins imu jointstate publisher node"""
     rclpy.init(args=args)
 
     minimal_publisher = IMUJointstatePublisher()

--- a/ada_imu/launch/ada_imu.launch.py
+++ b/ada_imu/launch/ada_imu.launch.py
@@ -11,7 +11,7 @@ from launch_ros.actions import Node
 
 
 def generate_launch_description():
-    """ Creates launch description to run imu_jointstate_publisher """
+    """Creates launch description to run imu_jointstate_publisher"""
     launch_description = LaunchDescription()
 
     config = os.path.join(

--- a/ada_imu/setup.py
+++ b/ada_imu/setup.py
@@ -2,29 +2,28 @@ from setuptools import setup
 import os
 from glob import glob
 
-package_name = 'ada_imu'
+package_name = "ada_imu"
 
 setup(
     name=package_name,
-    version='0.0.0',
+    version="0.0.0",
     packages=[package_name],
     data_files=[
-        ('share/ament_index/resource_index/packages',
-            ['resource/' + package_name]),
-        ('share/' + package_name, ['package.xml']),
-        (os.path.join('share', package_name, 'launch'), glob('launch/*.launch.py')),
-        (os.path.join('share', package_name, 'config'), glob('config/*.yaml')),
+        ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
+        ("share/" + package_name, ["package.xml"]),
+        (os.path.join("share", package_name, "launch"), glob("launch/*.launch.py")),
+        (os.path.join("share", package_name, "config"), glob("config/*.yaml")),
     ],
-    install_requires=['setuptools'],
+    install_requires=["setuptools"],
     zip_safe=True,
-    maintainer='Ethan K. Gordon',
-    maintainer_email='ekgordon@cs.washington.edu',
-    description='IMU jointstate publisher',
-    license='BSD-3-Clause',
-    tests_require=['pytest'],
+    maintainer="Ethan K. Gordon",
+    maintainer_email="ekgordon@cs.washington.edu",
+    description="IMU jointstate publisher",
+    license="BSD-3-Clause",
+    tests_require=["pytest"],
     entry_points={
-        'console_scripts': [
-            'imu_jointstate_publisher = ada_imu.imu_jointstate_publisher:main'
+        "console_scripts": [
+            "imu_jointstate_publisher = ada_imu.imu_jointstate_publisher:main"
         ],
     },
 )

--- a/ada_imu/test/test_copyright.py
+++ b/ada_imu/test/test_copyright.py
@@ -17,9 +17,11 @@ import pytest
 
 
 # Remove the `skip` decorator once the source file(s) have a copyright header
-@pytest.mark.skip(reason='No copyright header has been placed in the generated source file.')
+@pytest.mark.skip(
+    reason="No copyright header has been placed in the generated source file."
+)
 @pytest.mark.copyright
 @pytest.mark.linter
 def test_copyright():
-    rc = main(argv=['.', 'test'])
-    assert rc == 0, 'Found errors'
+    rc = main(argv=[".", "test"])
+    assert rc == 0, "Found errors"

--- a/ada_imu/test/test_pep257.py
+++ b/ada_imu/test/test_pep257.py
@@ -19,5 +19,5 @@ import pytest
 @pytest.mark.linter
 @pytest.mark.pep257
 def test_pep257():
-    rc = main(argv=['.', 'test'])
-    assert rc == 0, 'Found code style errors / warnings'
+    rc = main(argv=[".", "test"])
+    assert rc == 0, "Found code style errors / warnings"

--- a/ada_moveit/calib/default/calib1/camera_calib_pose.launch.py
+++ b/ada_moveit/calib/default/calib1/camera_calib_pose.launch.py
@@ -39,4 +39,3 @@ def generate_launch_description() -> LaunchDescription:
         ),
     ]
     return LaunchDescription(nodes)
-

--- a/ada_moveit/calib/default/calib2/camera_calib_pose.launch.py
+++ b/ada_moveit/calib/default/calib2/camera_calib_pose.launch.py
@@ -39,4 +39,3 @@ def generate_launch_description() -> LaunchDescription:
         ),
     ]
     return LaunchDescription(nodes)
-

--- a/ada_moveit/launch/demo.launch.py
+++ b/ada_moveit/launch/demo.launch.py
@@ -1,14 +1,16 @@
 from moveit_configs_utils import MoveItConfigsBuilder
 from moveit_configs_utils.launches import generate_demo_launch
 from launch import LaunchDescription
-from launch.actions import (
- DeclareLaunchArgument,
- IncludeLaunchDescription,
- LogInfo
-)
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, LogInfo
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration, Command, PathJoinSubstitution, FindExecutable, TextSubstitution
+from launch.substitutions import (
+    LaunchConfiguration,
+    Command,
+    PathJoinSubstitution,
+    FindExecutable,
+    TextSubstitution,
+)
 
 from launch_ros.actions import Node
 from launch_ros.parameter_descriptions import ParameterValue
@@ -16,36 +18,38 @@ from launch_ros.parameter_descriptions import ParameterValue
 from srdfdom.srdf import SRDF
 
 from moveit_configs_utils.launch_utils import (
- add_debuggable_node,
- DeclareBooleanLaunchArg,
+    add_debuggable_node,
+    DeclareBooleanLaunchArg,
 )
 
 
 def generate_launch_description():
     # MoveIt Config
-    moveit_config = MoveItConfigsBuilder("ada", package_name="ada_moveit").to_moveit_configs()
+    moveit_config = MoveItConfigsBuilder(
+        "ada", package_name="ada_moveit"
+    ).to_moveit_configs()
 
     # Calibration Launch Argument
     calib_da = DeclareLaunchArgument(
-            "calib",
-            default_value="default",
-            description="Which calibration folder to use with calib_camera_pose.launch.py"
-            )
+        "calib",
+        default_value="default",
+        description="Which calibration folder to use with calib_camera_pose.launch.py",
+    )
     calib = LaunchConfiguration("calib")
 
     # Sim Launch Argument
     sim_da = DeclareLaunchArgument(
-            "sim",
-            default_value="real",
-            description="Which sim to use: 'mock', 'isaac', or 'real'",
-        )
+        "sim",
+        default_value="real",
+        description="Which sim to use: 'mock', 'isaac', or 'real'",
+    )
     sim = LaunchConfiguration("sim")
 
     ctrl_da = DeclareLaunchArgument(
-            "controllers_file",
-            default_value=[sim, "_controllers.yaml"],
-            description="ROS2 Controller YAML configuration in config folder",
-        )
+        "controllers_file",
+        default_value=[sim, "_controllers.yaml"],
+        description="ROS2 Controller YAML configuration in config folder",
+    )
     controllers_file = LaunchConfiguration("controllers_file")
 
     # Copy from generate_demo_launch
@@ -56,80 +60,84 @@ def generate_launch_description():
 
     # Camera Calibration File
     ld.add_action(
-         IncludeLaunchDescription(
-             PythonLaunchDescriptionSource([
-                PathJoinSubstitution([
-                    str(moveit_config.package_path),
-                    'calib',
-                    calib,
-                    'calib_camera_pose.launch.py'
-                ])
-                ]),
-         )
-     )
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                [
+                    PathJoinSubstitution(
+                        [
+                            str(moveit_config.package_path),
+                            "calib",
+                            calib,
+                            "calib_camera_pose.launch.py",
+                        ]
+                    )
+                ]
+            ),
+        )
+    )
 
     ld.add_action(
-     DeclareBooleanLaunchArg(
-         "db",
-         default_value=False,
-         description="By default, we do not start a database (it can be large)",
-     )
+        DeclareBooleanLaunchArg(
+            "db",
+            default_value=False,
+            description="By default, we do not start a database (it can be large)",
+        )
     )
     ld.add_action(
-     DeclareBooleanLaunchArg(
-         "debug",
-         default_value=False,
-         description="By default, we are not in debug mode",
-     )
+        DeclareBooleanLaunchArg(
+            "debug",
+            default_value=False,
+            description="By default, we are not in debug mode",
+        )
     )
     ld.add_action(DeclareBooleanLaunchArg("use_rviz", default_value=True))
 
     # If there are virtual joints, broadcast static tf by including virtual_joints launch
     virtual_joints_launch = (
-     moveit_config.package_path / "launch/static_virtual_joint_tfs.launch.py"
+        moveit_config.package_path / "launch/static_virtual_joint_tfs.launch.py"
     )
     if virtual_joints_launch.exists():
-     ld.add_action(
-         IncludeLaunchDescription(
-             PythonLaunchDescriptionSource(str(virtual_joints_launch)),
-         )
-     )
+        ld.add_action(
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource(str(virtual_joints_launch)),
+            )
+        )
 
     # Given the published joint states, publish tf for the robot links
     ld.add_action(
-     IncludeLaunchDescription(
-         PythonLaunchDescriptionSource(
-             str(moveit_config.package_path / "launch/rsp.launch.py")
-         ),
-     )
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                str(moveit_config.package_path / "launch/rsp.launch.py")
+            ),
+        )
     )
 
     ld.add_action(
-     IncludeLaunchDescription(
-         PythonLaunchDescriptionSource(
-             str(moveit_config.package_path / "launch/move_group.launch.py")
-         ),
-     )
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                str(moveit_config.package_path / "launch/move_group.launch.py")
+            ),
+        )
     )
 
     # Run Rviz and load the default config to see the state of the move_group node
     ld.add_action(
-     IncludeLaunchDescription(
-         PythonLaunchDescriptionSource(
-             str(moveit_config.package_path / "launch/moveit_rviz.launch.py")
-         ),
-         condition=IfCondition(LaunchConfiguration("use_rviz")),
-     )
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                str(moveit_config.package_path / "launch/moveit_rviz.launch.py")
+            ),
+            condition=IfCondition(LaunchConfiguration("use_rviz")),
+        )
     )
 
     # If database loading was enabled, start mongodb as well
     ld.add_action(
-     IncludeLaunchDescription(
-         PythonLaunchDescriptionSource(
-             str(moveit_config.package_path / "launch/warehouse_db.launch.py")
-         ),
-         condition=IfCondition(LaunchConfiguration("db")),
-     )
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                str(moveit_config.package_path / "launch/warehouse_db.launch.py")
+            ),
+            condition=IfCondition(LaunchConfiguration("db")),
+        )
     )
 
     # Get URDF via xacro
@@ -137,40 +145,37 @@ def generate_launch_description():
         [
             PathJoinSubstitution([FindExecutable(name="xacro")]),
             " ",
-            PathJoinSubstitution(str(moveit_config.package_path / "config/ada.urdf.xacro")),
+            PathJoinSubstitution(
+                str(moveit_config.package_path / "config/ada.urdf.xacro")
+            ),
             " ",
             "sim:=",
             sim,
         ]
     )
-    robot_description = {"robot_description": ParameterValue(robot_description_content, value_type=str)}
+    robot_description = {
+        "robot_description": ParameterValue(robot_description_content, value_type=str)
+    }
 
     robot_controllers = PathJoinSubstitution(
-        [
-            str(moveit_config.package_path),
-            "config",
-            controllers_file
-        ]
+        [str(moveit_config.package_path), "config", controllers_file]
     )
 
     # Joint Controllers
     ld.add_action(
-     Node(
-         package="controller_manager",
-         executable="ros2_control_node",
-         parameters=[
-             robot_description,
-             robot_controllers
-         ],
-     )
+        Node(
+            package="controller_manager",
+            executable="ros2_control_node",
+            parameters=[robot_description, robot_controllers],
+        )
     )
 
     ld.add_action(
-     IncludeLaunchDescription(
-         PythonLaunchDescriptionSource(
-             str(moveit_config.package_path / "launch/spawn_controllers.launch.py")
-         ),
-     )
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                str(moveit_config.package_path / "launch/spawn_controllers.launch.py")
+            ),
+        )
     )
 
     return ld

--- a/ada_moveit/launch/demo_feeding.launch.py
+++ b/ada_moveit/launch/demo_feeding.launch.py
@@ -1,8 +1,8 @@
 from moveit_configs_utils import MoveItConfigsBuilder
 from launch import LaunchDescription
 from launch.actions import (
- IncludeLaunchDescription,
- Shutdown,
+    IncludeLaunchDescription,
+    Shutdown,
 )
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 
@@ -14,38 +14,40 @@ from srdfdom.srdf import SRDF
 
 def generate_launch_description():
     # MoveIt Config
-    moveit_config = MoveItConfigsBuilder("ada", package_name="ada_moveit").to_moveit_configs()
+    moveit_config = MoveItConfigsBuilder(
+        "ada", package_name="ada_moveit"
+    ).to_moveit_configs()
 
     # Create the launch description and populate
     ld = LaunchDescription()
 
     # Add the default demo.launch.py
     ld.add_action(
-     IncludeLaunchDescription(
-         PythonLaunchDescriptionSource(
-             str(moveit_config.package_path / "launch/demo.launch.py")
-         ),
-     )
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                str(moveit_config.package_path / "launch/demo.launch.py")
+            ),
+        )
     )
 
     # Add the watchdog listener node
     watchdog_timeout = {"watchdog_timeout": ParameterValue(0.1, value_type=float)}
     watchdog_check_hz = {"watchdog_check_hz": ParameterValue(60.0, value_type=float)}
-    initial_wait_time_sec = {"initial_wait_time_sec": ParameterValue(2.0, value_type=float)}
+    initial_wait_time_sec = {
+        "initial_wait_time_sec": ParameterValue(2.0, value_type=float)
+    }
     ld.add_action(
-     Node(
-         package="ada_watchdog_listener",
-         executable="ada_watchdog_listener_node",
-         parameters=[
-             watchdog_timeout,
-             watchdog_check_hz,
-             initial_wait_time_sec,
-         ],
-         remappings=[
-             ("~/watchdog", "/ada_watchdog/watchdog")
-         ],
-         on_exit=Shutdown(),
-     )
+        Node(
+            package="ada_watchdog_listener",
+            executable="ada_watchdog_listener_node",
+            parameters=[
+                watchdog_timeout,
+                watchdog_check_hz,
+                initial_wait_time_sec,
+            ],
+            remappings=[("~/watchdog", "/ada_watchdog/watchdog")],
+            on_exit=Shutdown(),
+        )
     )
 
     return ld

--- a/ada_moveit/launch/move_group.launch.py
+++ b/ada_moveit/launch/move_group.launch.py
@@ -3,5 +3,7 @@ from moveit_configs_utils.launches import generate_move_group_launch
 
 
 def generate_launch_description():
-    moveit_config = MoveItConfigsBuilder("ada", package_name="ada_moveit").to_moveit_configs()
+    moveit_config = MoveItConfigsBuilder(
+        "ada", package_name="ada_moveit"
+    ).to_moveit_configs()
     return generate_move_group_launch(moveit_config)

--- a/ada_moveit/launch/moveit_rviz.launch.py
+++ b/ada_moveit/launch/moveit_rviz.launch.py
@@ -3,5 +3,7 @@ from moveit_configs_utils.launches import generate_moveit_rviz_launch
 
 
 def generate_launch_description():
-    moveit_config = MoveItConfigsBuilder("ada", package_name="ada_moveit").to_moveit_configs()
+    moveit_config = MoveItConfigsBuilder(
+        "ada", package_name="ada_moveit"
+    ).to_moveit_configs()
     return generate_moveit_rviz_launch(moveit_config)

--- a/ada_moveit/launch/rsp.launch.py
+++ b/ada_moveit/launch/rsp.launch.py
@@ -3,5 +3,7 @@ from moveit_configs_utils.launches import generate_rsp_launch
 
 
 def generate_launch_description():
-    moveit_config = MoveItConfigsBuilder("ada", package_name="ada_moveit").to_moveit_configs()
+    moveit_config = MoveItConfigsBuilder(
+        "ada", package_name="ada_moveit"
+    ).to_moveit_configs()
     return generate_rsp_launch(moveit_config)

--- a/ada_moveit/launch/setup_assistant.launch.py
+++ b/ada_moveit/launch/setup_assistant.launch.py
@@ -3,5 +3,7 @@ from moveit_configs_utils.launches import generate_setup_assistant_launch
 
 
 def generate_launch_description():
-    moveit_config = MoveItConfigsBuilder("ada", package_name="ada_moveit").to_moveit_configs()
+    moveit_config = MoveItConfigsBuilder(
+        "ada", package_name="ada_moveit"
+    ).to_moveit_configs()
     return generate_setup_assistant_launch(moveit_config)

--- a/ada_moveit/launch/spawn_controllers.launch.py
+++ b/ada_moveit/launch/spawn_controllers.launch.py
@@ -3,5 +3,7 @@ from moveit_configs_utils.launches import generate_spawn_controllers_launch
 
 
 def generate_launch_description():
-    moveit_config = MoveItConfigsBuilder("ada", package_name="ada_moveit").to_moveit_configs()
+    moveit_config = MoveItConfigsBuilder(
+        "ada", package_name="ada_moveit"
+    ).to_moveit_configs()
     return generate_spawn_controllers_launch(moveit_config)

--- a/ada_moveit/launch/static_virtual_joint_tfs.launch.py
+++ b/ada_moveit/launch/static_virtual_joint_tfs.launch.py
@@ -3,5 +3,7 @@ from moveit_configs_utils.launches import generate_static_virtual_joint_tfs_laun
 
 
 def generate_launch_description():
-    moveit_config = MoveItConfigsBuilder("ada", package_name="ada_moveit").to_moveit_configs()
+    moveit_config = MoveItConfigsBuilder(
+        "ada", package_name="ada_moveit"
+    ).to_moveit_configs()
     return generate_static_virtual_joint_tfs_launch(moveit_config)

--- a/ada_moveit/launch/warehouse_db.launch.py
+++ b/ada_moveit/launch/warehouse_db.launch.py
@@ -3,5 +3,7 @@ from moveit_configs_utils.launches import generate_warehouse_db_launch
 
 
 def generate_launch_description():
-    moveit_config = MoveItConfigsBuilder("ada", package_name="ada_moveit").to_moveit_configs()
+    moveit_config = MoveItConfigsBuilder(
+        "ada", package_name="ada_moveit"
+    ).to_moveit_configs()
     return generate_warehouse_db_launch(moveit_config)


### PR DESCRIPTION
This PR runs `python3 -m black .` at the top-level of this repository to get all files black formatted. This makes it easier for future developers to run black formatting, since they don't have to worry about adding unnecessary changes to their branch.

Testing shbould not be necessary since this is only formatting. Nevertheless, I ran `ros2 launch ada_moveit demo.launch.py sim:=mock` and verified that it works as expected.