### PR TITLE
Implement Octomap

### DIFF
--- a/ada_description/urdf/forque/forque.xacro
+++ b/ada_description/urdf/forque/forque.xacro
@@ -83,7 +83,7 @@
 	  	<xacro:forque_assembly_link link_name="forkHandle" link_mesh="2023_03_09_forkHandle" mass="0.0506" cog="0.0110024 -0.151715 -0.00934664">
 	  		<xacro:insert_block name="default_inertial"/>
 	  	</xacro:forque_assembly_link>
-	  	<xacro:forque_assembly_joint joint_name="forkHandle_to_FTMount" parent="FTMount" child="forkHandle" joint_origin_xyz="0 0 0" joint_origin_rpy="0 0 0"/>
+	  	<xacro:forque_assembly_joint joint_name="forkHandle_to_FTMount" parent="FTMount" child="forkHandle" joint_origin_xyz="0 0 0" joint_origin_rpy="-0.0075 0 0"/>
 
 	  	<xacro:forque_assembly_link link_name="forque" link_mesh="ATI-9105-TW-NANO25-E" mass="0.0634" cog="0.0124692 0.0137169 0.010558">
 	  		<xacro:insert_block name="default_inertial"/>

--- a/ada_description/urdf/forque/forque.xacro
+++ b/ada_description/urdf/forque/forque.xacro
@@ -83,6 +83,7 @@
 	  	<xacro:forque_assembly_link link_name="forkHandle" link_mesh="2023_03_09_forkHandle" mass="0.0506" cog="0.0110024 -0.151715 -0.00934664">
 	  		<xacro:insert_block name="default_inertial"/>
 	  	</xacro:forque_assembly_link>
+		<!-- The slight rotation was manually added due to empirical deformations in the robot gripped, such that the fingers and fork handle were slightly pitched up relative to the wrist. -->
 	  	<xacro:forque_assembly_joint joint_name="forkHandle_to_FTMount" parent="FTMount" child="forkHandle" joint_origin_xyz="0 0 0" joint_origin_rpy="-0.0075 0 0"/>
 
 	  	<xacro:forque_assembly_link link_name="forque" link_mesh="ATI-9105-TW-NANO25-E" mass="0.0634" cog="0.0124692 0.0137169 0.010558">

--- a/ada_moveit/calib/manual/calib_camera_pose.launch.py
+++ b/ada_moveit/calib/manual/calib_camera_pose.launch.py
@@ -1,0 +1,32 @@
+""" Static transform publisher acquired via MoveIt 2 hand-eye calibration """
+""" EYE-IN-HAND: j2n6s200_end_effector -> camera_color_optical_frame """
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+def generate_launch_description() -> LaunchDescription:
+    nodes = [
+        Node(
+            package="tf2_ros",
+            executable="static_transform_publisher",
+            output="log",
+            arguments=[
+                "--frame-id",
+                "j2n6s200_end_effector",
+                "--child-frame-id",
+                "camera_color_optical_frame",
+                "--x",
+                "0.032",
+                "--y",
+                "0.129",
+                "--z",
+                "-0.155",
+                "--roll",
+                "-0.229",
+                "--pitch",
+                "0.0",
+                "--yaw",
+                "-3.14",
+            ],
+        ),
+    ]
+    return LaunchDescription(nodes)

--- a/ada_moveit/calib/manual/calib_camera_pose.launch.py
+++ b/ada_moveit/calib/manual/calib_camera_pose.launch.py
@@ -3,6 +3,12 @@
 from launch import LaunchDescription
 from launch_ros.actions import Node
 
+# NOTE: This was hand-tweaked, assimng 0 pitch and -3.14 yaw
+# (i.e., assuming the only unknown orientation was pitch)
+# by having the camera observe the robot itself (point at
+# joint 1) and comparing the depthcloud to the robot's mesh
+# in RVIZ. The transform was then adjusted until the depthcloud
+# visually matched the mesh.
 def generate_launch_description() -> LaunchDescription:
     nodes = [
         Node(

--- a/ada_moveit/config/sensors_3d.yaml
+++ b/ada_moveit/config/sensors_3d.yaml
@@ -11,6 +11,6 @@ default_sensor:
   shadow_threshold: 0.2
   padding_scale: 4.0
   padding_offset: 0.03
-  max_update_rate: 1.0
+  max_update_rate: 3.0
   filtered_cloud_topic: filtered_cloud
   

--- a/ada_moveit/config/sensors_3d.yaml
+++ b/ada_moveit/config/sensors_3d.yaml
@@ -1,3 +1,5 @@
+octomap_frame: camera_color_optical_frame
+octomap_resolution: 0.02
 sensors:
   - default_sensor
 default_sensor:
@@ -11,3 +13,4 @@ default_sensor:
   padding_offset: 0.03
   max_update_rate: 1.0
   filtered_cloud_topic: filtered_cloud
+  

--- a/ada_moveit/config/sensors_3d.yaml
+++ b/ada_moveit/config/sensors_3d.yaml
@@ -4,7 +4,7 @@ sensors:
   - default_sensor
 default_sensor:
   sensor_plugin: occupancy_map_monitor/DepthImageOctomapUpdater
-  image_topic: /camera/aligned_depth_to_color/image_raw
+  image_topic: /local/camera/aligned_depth_to_color/image_raw
   queue_size: 1
   near_clipping_plane_distance: 0.02
   far_clipping_plane_distance: 5.0

--- a/ada_moveit/config/sensors_3d.yaml
+++ b/ada_moveit/config/sensors_3d.yaml
@@ -1,13 +1,13 @@
 sensors:
   - default_sensor
 default_sensor:
-  far_clipping_plane_distance: 5.0
-  filtered_cloud_topic: filtered_cloud
-  image_topic: /camera/aligned_depth_to_color/image_raw
-  max_update_rate: 1.0
-  near_clipping_plane_distance: 0.02
-  padding_offset: 0.03
-  padding_scale: 4.0
-  queue_size: 5
   sensor_plugin: occupancy_map_monitor/DepthImageOctomapUpdater
+  image_topic: /camera/aligned_depth_to_color/image_raw
+  queue_size: 1
+  near_clipping_plane_distance: 0.02
+  far_clipping_plane_distance: 5.0
   shadow_threshold: 0.2
+  padding_scale: 4.0
+  padding_offset: 0.03
+  max_update_rate: 1.0
+  filtered_cloud_topic: filtered_cloud

--- a/ada_moveit/config/sensors_3d.yaml
+++ b/ada_moveit/config/sensors_3d.yaml
@@ -4,7 +4,7 @@ sensors:
   - default_sensor
 default_sensor:
   sensor_plugin: occupancy_map_monitor/DepthImageOctomapUpdater
-  image_topic: /local/camera/aligned_depth_to_color/image_raw
+  image_topic:  /local/camera/aligned_depth_to_color/depth_octomap
   queue_size: 1
   near_clipping_plane_distance: 0.02
   far_clipping_plane_distance: 5.0

--- a/ada_moveit/launch/demo.launch.py
+++ b/ada_moveit/launch/demo.launch.py
@@ -35,7 +35,7 @@ def generate_launch_description():
     # Calibration Launch Argument
     calib_da = DeclareLaunchArgument(
         "calib",
-        default_value="default",
+        default_value="manual",
         description="Which calibration folder to use with calib_camera_pose.launch.py",
     )
     calib = LaunchConfiguration("calib")


### PR DESCRIPTION
# Description

Joint PR with [`ada_feeding`#125](https://github.com/personalrobotics/ada_feeding/pull/125).

This PR does the following:
1. Implements Octomap in MoveIt.
2. Adds a manual camera calibration that seems to work quite well.
3. Rotates the fork handle up slightly in the URDF, to align that small degree of freedom with what the depth camera sees.

# Testing

See [`ada_feeding`#125](https://github.com/personalrobotics/ada_feeding/pull/125).