### PR TITLE
Disabled SRDF Collisions to Re-enable MoveIt Servo

### DIFF
--- a/ada_moveit/config/ada.srdf
+++ b/ada_moveit/config/ada.srdf
@@ -256,4 +256,6 @@
     <disable_collisions link1="cameraMount" link2="uncalibrated_camera_link" reason="Adjacent"/>
     <disable_collisions link1="frontStabilizer" link2="enclosureBottom" reason="Adjacent"/>
     <disable_collisions link1="j2n6s200_link_6" link2="frontStabilizer" reason="Adjacent"/>
+    <disable_collisions link1="frontStabilizer" link2="enclosureTop" reason="Nearby, necessary because MoveIt Servo slows near collisions"/>
+    <disable_collisions link1="nano" link2="frontStabilizer" reason="Nearby, necessary because MoveIt Servo slows near collisions"/>
 </robot>

--- a/ada_moveit/config/ada.srdf
+++ b/ada_moveit/config/ada.srdf
@@ -256,6 +256,7 @@
     <disable_collisions link1="cameraMount" link2="uncalibrated_camera_link" reason="Adjacent"/>
     <disable_collisions link1="frontStabilizer" link2="enclosureBottom" reason="Adjacent"/>
     <disable_collisions link1="j2n6s200_link_6" link2="frontStabilizer" reason="Adjacent"/>
-    <disable_collisions link1="frontStabilizer" link2="enclosureTop" reason="Nearby, necessary because MoveIt Servo slows near collisions"/>
-    <disable_collisions link1="nano" link2="frontStabilizer" reason="Nearby, necessary because MoveIt Servo slows near collisions"/>
+    <!-- The below links are close enough to each other that MoveIt Servo thinks a collision is always imminent -->
+    <disable_collisions link1="frontStabilizer" link2="enclosureTop" reason="Never"/>
+    <disable_collisions link1="nano" link2="frontStabilizer" reason="Never"/>
 </robot>


### PR DESCRIPTION
# Description

Given our current configuration, MoveIt Servo starts decelerating if the robot is 2cm from a collision. Because the `frontStabilizer` is within 2cm of the `enclosureTop` link and the `nano` link, the robot thinks it is constantly near collision, so doesn't move. This PR addresses that by disabling the collisions.

# Testing

- [x] Follow the[ instructions in the README to run MoveIt Servo with keyboard teleop](https://github.com/personalrobotics/ada_ros2#moveit-servo). Verify that the robot moves.
- [x] One at a time, comment out each added lines in the SRDF, re-build, and re-run MoveIt Servo. Verify that it doesn't move.

This demonstrates that: (a) disabling those two collisions solves the problem; and (b) both disabled collisions are necessary to allow MoveIt Servo to work.