### PR TITLE
Removed close collisions to re-enable servo

### DIFF
--- a/ada_moveit/config/ada.srdf
+++ b/ada_moveit/config/ada.srdf
@@ -259,5 +259,7 @@
     <disable_collisions link1="nano" link2="frontStabilizer" reason="Never"/>
     <disable_collisions link1="cameraMount" link2="screwHeadLeft" reason="Adjacent"/>
     <disable_collisions link1="cameraMount" link2="screwHeadRight" reason="Adjacent"/>
+    <disable_collisions link1="uncalibrated_camera_link" link2="screwHeadLeft" reason="Adjacent"/>
+    <disable_collisions link1="uncalibrated_camera_link" link2="screwHeadRight" reason="Adjacent"/>
 
 </robot>


### PR DESCRIPTION
Servo won't move within 2cm of collision. Because the screws and the camera were always closer than that, servo would never move. This PR addresses that.