### PR TITLE
Update Octomap to work with servo for bite transfer

### DIFF
--- a/ada_moveit/config/mock_servo.yaml
+++ b/ada_moveit/config/mock_servo.yaml
@@ -57,8 +57,8 @@ servo_node:
       num_outgoing_halt_msgs_to_publish: 0
 
       ## Configure handling of singularities and joint limits
-      lower_singularity_threshold:  60.0  # Start decelerating when the condition number hits this (close to singularity)
-      hard_stop_singularity_threshold: 100.0 # Stop when the condition number hits this
+      lower_singularity_threshold:  100.0  # Start decelerating when the condition number hits this (close to singularity)
+      hard_stop_singularity_threshold: 200.0 # Stop when the condition number hits this
       joint_limit_margin: 0.2 # added as a buffer to joint limits [radians]. If moving quickly, make this larger.
       leaving_singularity_threshold_multiplier: 2.0 # Multiply the hard stop limit by this when leaving singularity (see https://github.com/ros-planning/moveit2/pull/620)
 

--- a/ada_moveit/config/mock_servo.yaml
+++ b/ada_moveit/config/mock_servo.yaml
@@ -40,6 +40,7 @@ servo_node:
       # NOTE: If a different node in your system is responsible for the "primary" planning scene instance (e.g. the MoveGroup node),
       # then is_primary_planning_scene_monitor needs to be set to false.
       is_primary_planning_scene_monitor: false
+      monitored_planning_scene_topic: "monitored_planning_scene"
 
       ## MoveIt properties
       move_group_name:  jaco_arm  # Often 'manipulator' or 'arm'

--- a/ada_moveit/config/mock_servo.yaml
+++ b/ada_moveit/config/mock_servo.yaml
@@ -57,8 +57,8 @@ servo_node:
       num_outgoing_halt_msgs_to_publish: 0
 
       ## Configure handling of singularities and joint limits
-      lower_singularity_threshold:  30.0  # Start decelerating when the condition number hits this (close to singularity)
-      hard_stop_singularity_threshold: 90.0 # Stop when the condition number hits this
+      lower_singularity_threshold:  60.0  # Start decelerating when the condition number hits this (close to singularity)
+      hard_stop_singularity_threshold: 100.0 # Stop when the condition number hits this
       joint_limit_margin: 0.2 # added as a buffer to joint limits [radians]. If moving quickly, make this larger.
       leaving_singularity_threshold_multiplier: 2.0 # Multiply the hard stop limit by this when leaving singularity (see https://github.com/ros-planning/moveit2/pull/620)
 

--- a/ada_moveit/config/real_servo.yaml
+++ b/ada_moveit/config/real_servo.yaml
@@ -57,8 +57,8 @@ servo_node:
       num_outgoing_halt_msgs_to_publish: 0
 
       ## Configure handling of singularities and joint limits
-      lower_singularity_threshold:  60.0  # Start decelerating when the condition number hits this (close to singularity)
-      hard_stop_singularity_threshold: 100.0 # Stop when the condition number hits this
+      lower_singularity_threshold:  100.0  # Start decelerating when the condition number hits this (close to singularity)
+      hard_stop_singularity_threshold: 200.0 # Stop when the condition number hits this
       joint_limit_margin: 0.2 # added as a buffer to joint limits [radians]. If moving quickly, make this larger.
       leaving_singularity_threshold_multiplier: 2.0 # Multiply the hard stop limit by this when leaving singularity (see https://github.com/ros-planning/moveit2/pull/620)
 

--- a/ada_moveit/config/real_servo.yaml
+++ b/ada_moveit/config/real_servo.yaml
@@ -40,6 +40,7 @@ servo_node:
       # NOTE: If a different node in your system is responsible for the "primary" planning scene instance (e.g. the MoveGroup node),
       # then is_primary_planning_scene_monitor needs to be set to false.
       is_primary_planning_scene_monitor: false
+      monitored_planning_scene_topic: "monitored_planning_scene"
 
       ## MoveIt properties
       move_group_name:  jaco_arm  # Often 'manipulator' or 'arm'
@@ -72,4 +73,4 @@ servo_node:
       check_collisions: true # Check collisions?
       collision_check_rate: 10.0 # [Hz] Collision-checking can easily bog down a CPU if done too often.
       self_collision_proximity_threshold: 0.01 # Start decelerating when a self-collision is this far [m]
-      scene_collision_proximity_threshold: 0.0001 # Start decelerating when a scene collision is this far [m]
+      scene_collision_proximity_threshold: 0.01 # Start decelerating when a scene collision is this far [m]

--- a/ada_moveit/config/real_servo.yaml
+++ b/ada_moveit/config/real_servo.yaml
@@ -57,8 +57,8 @@ servo_node:
       num_outgoing_halt_msgs_to_publish: 0
 
       ## Configure handling of singularities and joint limits
-      lower_singularity_threshold:  30.0  # Start decelerating when the condition number hits this (close to singularity)
-      hard_stop_singularity_threshold: 90.0 # Stop when the condition number hits this
+      lower_singularity_threshold:  60.0  # Start decelerating when the condition number hits this (close to singularity)
+      hard_stop_singularity_threshold: 100.0 # Stop when the condition number hits this
       joint_limit_margin: 0.2 # added as a buffer to joint limits [radians]. If moving quickly, make this larger.
       leaving_singularity_threshold_multiplier: 2.0 # Multiply the hard stop limit by this when leaving singularity (see https://github.com/ros-planning/moveit2/pull/620)
 

--- a/ada_moveit/config/sensors_3d.yaml
+++ b/ada_moveit/config/sensors_3d.yaml
@@ -9,8 +9,8 @@ default_sensor:
   near_clipping_plane_distance: 0.02
   far_clipping_plane_distance: 5.0
   shadow_threshold: 0.2
-  padding_scale: 4.0
-  padding_offset: 0.03
+  padding_scale: 1.0
+  padding_offset: 0.00
   max_update_rate: 3.0
   filtered_cloud_topic: filtered_cloud
   


### PR DESCRIPTION
As of [ada_feeding#135](https://github.com/personalrobotics/ada_feeding/pull/135) and [PRL's fork of moveit2 (branch: `amaln/main`)](https://github.com/personalrobotics/moveit2/tree/amaln/main), we were facing two issues with the `servo_node` respecting the Octomap:

1. The servo_node would allow the robot to move right up till the point of collision, which would sometimes result in real-world collisions due to mismatches between the planning scene and real world or due to the servo node not being able to stop in time.
2. As the robot moves closer to the Octomap, the Octomap's default self-filtering starts thinking the colliding voxels are part of the robot arm and removes them from the Octomap.

This PR addresses that in two ways:

1. Start decelerating servo at 1cm from collision.
2. Remove the scaling and padding offset on the Octomap, so that it only removes voxels that directly overlap with the robot, not in an expanded radius around the robot. (Note: this means that the camera calibration needs to be good, to prevent detected robot voxels from appearing as collisions.)