### PR TITLE
Modify parameters to servo to mouth with obstacles around mouth

### DIFF
--- a/ada_moveit/config/mock_servo.yaml
+++ b/ada_moveit/config/mock_servo.yaml
@@ -72,5 +72,5 @@ servo_node:
       ## Collision checking for the entire robot body
       check_collisions: true # Check collisions?
       collision_check_rate: 10.0 # [Hz] Collision-checking can easily bog down a CPU if done too often.
-      self_collision_proximity_threshold: 0.01 # Start decelerating when a self-collision is this far [m]
+      self_collision_proximity_threshold: 0.001 # Start decelerating when a self-collision is this far [m]
       scene_collision_proximity_threshold: 0.0001 # Start decelerating when a scene collision is this far [m]

--- a/ada_moveit/config/real_servo.yaml
+++ b/ada_moveit/config/real_servo.yaml
@@ -72,5 +72,5 @@ servo_node:
       ## Collision checking for the entire robot body
       check_collisions: true # Check collisions?
       collision_check_rate: 10.0 # [Hz] Collision-checking can easily bog down a CPU if done too often.
-      self_collision_proximity_threshold: 0.01 # Start decelerating when a self-collision is this far [m]
+      self_collision_proximity_threshold: 0.001 # Start decelerating when a self-collision is this far [m]
       scene_collision_proximity_threshold: 0.01 # Start decelerating when a scene collision is this far [m]

--- a/ada_moveit/config/sensors_3d.yaml
+++ b/ada_moveit/config/sensors_3d.yaml
@@ -9,8 +9,8 @@ default_sensor:
   near_clipping_plane_distance: 0.02
   far_clipping_plane_distance: 5.0
   shadow_threshold: 0.2
-  padding_scale: 1.0
-  padding_offset: 0.00
+  padding_scale: 4.0
+  padding_offset: 0.03
   max_update_rate: 3.0
   filtered_cloud_topic: filtered_cloud
   


### PR DESCRIPTION
Paired with [`ada_feeding`#142](https://github.com/personalrobotics/ada_feeding/pull/142), this PR is necessary to update servo parameters to work now that we are detecting obstacles around the mouth in the Octomap.