### PR TITLE
Remove Octomap in sim mock

### DIFF
--- a/ada_moveit/launch/demo.launch.py
+++ b/ada_moveit/launch/demo.launch.py
@@ -142,6 +142,9 @@ def generate_launch_description():
             PythonLaunchDescriptionSource(
                 str(moveit_config.package_path / "launch/move_group.launch.py")
             ),
+            launch_arguments={
+                "sim": sim,
+            }.items(),
         )
     )
 

--- a/ada_moveit/launch/move_group.launch.py
+++ b/ada_moveit/launch/move_group.launch.py
@@ -1,9 +1,40 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
+from launch.substitutions import LaunchConfiguration
 from moveit_configs_utils import MoveItConfigsBuilder
 from moveit_configs_utils.launches import generate_move_group_launch
 
+def get_move_group_launch(context):
+    """
+    Gets the launch description for MoveGroup, after removing sensors_3d
+    if sim is mock.
 
-def generate_launch_description():
+    Adapted from https://robotics.stackexchange.com/questions/104340/getting-the-value-of-launchargument-inside-python-launch-file
+    """
+    sim = LaunchConfiguration("sim").perform(context)
+
+    # Get MoveIt Configs
     moveit_config = MoveItConfigsBuilder(
         "ada", package_name="ada_moveit"
     ).to_moveit_configs()
-    return generate_move_group_launch(moveit_config)
+
+    # If sim is mock, set moveit_config.sensors_3d to an empty dictionary
+    if sim == "mock":
+        moveit_config.sensors_3d = {}
+
+    return generate_move_group_launch(moveit_config).entities
+
+def generate_launch_description():
+    # Sim Launch Argument
+    sim_da = DeclareLaunchArgument(
+        "sim",
+        default_value="real",
+        description="Which sim to use: 'mock', 'isaac', or 'real'",
+    )
+
+    ld = LaunchDescription()
+    ld.add_action(sim_da)
+    ld.add_action(
+        OpaqueFunction(function=get_move_group_launch)
+    )
+    return ld


### PR DESCRIPTION
# Description

In practice, the Octomap doesn't work well in sim mock, because the dummy RealSense node just publishes a static depth image irrespective of where the robot arm is. As a result, [we ask users to modify `sensors_3d.yaml` to disable the Octomap in mock](https://github.com/personalrobotics/ada_feeding/blob/ros2-devel/README.md#option-b-running-web-app-with-the-mock-robot). However, modifying a yaml file depending on whether you're simulating a robot or not is undesirable.

Thus, this PR modifies `ada_moveit` launch so that if `sim:=mock`, it does not pass in information from `sensors_3d.yaml` to the MoveGroup.

# Testing

- [x] Pull the latest code and re-build your workspace.
- [x] Verify that your `sensors_3d.yaml` file has no local changes.
- [x] Run the code in sim: `python3 src/ada_feeding/start.py --sim mock`
- [x] Use the web app to move the robot, verify that there is no Octomap in RVIZ.
- [x] Verify that the Octomap has no subscribers: `ros2 topic info /local/camera/aligned_depth_to_color/depth_octomap -v`
- [x] Run the code in real: `python3 src/ada_feeding/start.py`
- [x] Use the web app to move the robot, verify that there is the expected Octomap in RVIZ.

**TODO:** Update README instructions to [remove the part about modifying `sensors_3d.yaml`](https://github.com/personalrobotics/ada_feeding/blob/ros2-devel/README.md#option-b-running-web-app-with-the-mock-robot).