### PR TITLE
Allow Command-Line Configuration of Log Level

### DIFF
--- a/ada_imu/launch/ada_imu.launch.py
+++ b/ada_imu/launch/ada_imu.launch.py
@@ -25,6 +25,13 @@ def generate_launch_description():
     )
     sim = LaunchConfiguration("sim")
     launch_description.add_action(sim_da)
+    log_level_da = DeclareLaunchArgument(
+        "log_level",
+        default_value="info",
+        description="Logging level (debug, info, warn, error, fatal)",
+    )
+    log_level = LaunchConfiguration("log_level")
+    launch_description.add_action(log_level_da)
 
     # Load the parameters
     config = os.path.join(
@@ -37,6 +44,7 @@ def generate_launch_description():
         name="imu_jointstate_publisher",
         executable="imu_jointstate_publisher",
         parameters=[config, sim_param],
+        arguments=['--ros-args', '--log-level', log_level],
     )
 
     launch_description.add_action(imu_jointstate_publisher)

--- a/ada_moveit/calib/autocalib/calib_camera_pose.launch.py
+++ b/ada_moveit/calib/autocalib/calib_camera_pose.launch.py
@@ -1,10 +1,20 @@
 """ Static transform publisher acquired via MoveIt 2 hand-eye calibration """
 """ EYE-IN-HAND: j2n6s200_end_effector -> camera_color_optical_frame """
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
 def generate_launch_description() -> LaunchDescription:
+    # Log Level
+    log_level_da = DeclareLaunchArgument(
+        "log_level",
+        default_value="info",
+        description="Logging level (debug, info, warn, error, fatal)",
+    )
+    log_level = LaunchConfiguration("log_level")
+    
     nodes = [
         Node(
             package="tf2_ros",
@@ -29,7 +39,10 @@ def generate_launch_description() -> LaunchDescription:
                 "-0.0876462",
                 "--qw",
                 "-0.0959528",
+                '--ros-args',
+                '--log-level',
+                log_level,
             ],
         ),
     ]
-    return LaunchDescription(nodes)
+    return LaunchDescription([log_level_da] + nodes)

--- a/ada_moveit/calib/default/calib1/camera_calib_pose.launch.py
+++ b/ada_moveit/calib/default/calib1/camera_calib_pose.launch.py
@@ -1,10 +1,20 @@
 """ Static transform publisher acquired via MoveIt 2 hand-eye calibration """
 """ EYE-IN-HAND: j2n6s200_end_effector -> camera_color_optical_frame """
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
 def generate_launch_description() -> LaunchDescription:
+    # Log Level
+    log_level_da = DeclareLaunchArgument(
+        "log_level",
+        default_value="info",
+        description="Logging level (debug, info, warn, error, fatal)",
+    )
+    log_level = LaunchConfiguration("log_level")
+    
     nodes = [
         Node(
             package="tf2_ros",
@@ -35,7 +45,10 @@ def generate_launch_description() -> LaunchDescription:
                 # "-0.00166814",
                 # "--yaw",
                 # "-3.13232",
+                '--ros-args',
+                '--log-level',
+                log_level,
             ],
         ),
     ]
-    return LaunchDescription(nodes)
+    return LaunchDescription([log_level_da] + nodes)

--- a/ada_moveit/calib/default/calib2/camera_calib_pose.launch.py
+++ b/ada_moveit/calib/default/calib2/camera_calib_pose.launch.py
@@ -1,10 +1,20 @@
 """ Static transform publisher acquired via MoveIt 2 hand-eye calibration """
 """ EYE-IN-HAND: j2n6s200_end_effector -> camera_color_optical_frame """
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
 def generate_launch_description() -> LaunchDescription:
+    # Log Level
+    log_level_da = DeclareLaunchArgument(
+        "log_level",
+        default_value="info",
+        description="Logging level (debug, info, warn, error, fatal)",
+    )
+    log_level = LaunchConfiguration("log_level")
+    
     nodes = [
         Node(
             package="tf2_ros",
@@ -35,7 +45,10 @@ def generate_launch_description() -> LaunchDescription:
                 # "0.00241343",
                 # "--yaw",
                 # "3.13318",
+                '--ros-args',
+                '--log-level',
+                log_level,
             ],
         ),
     ]
-    return LaunchDescription(nodes)
+    return LaunchDescription([log_level_da] + nodes)

--- a/ada_moveit/calib/default/calib_camera_pose.launch.py
+++ b/ada_moveit/calib/default/calib_camera_pose.launch.py
@@ -1,10 +1,20 @@
 """ Static transform publisher acquired via MoveIt 2 hand-eye calibration """
 """ EYE-IN-HAND: j2n6s200_end_effector -> camera_color_optical_frame """
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
 def generate_launch_description() -> LaunchDescription:
+     # Log Level
+    log_level_da = DeclareLaunchArgument(
+        "log_level",
+        default_value="info",
+        description="Logging level (debug, info, warn, error, fatal)",
+    )
+    log_level = LaunchConfiguration("log_level")
+
     nodes = [
         Node(
             package="tf2_ros",
@@ -27,7 +37,10 @@ def generate_launch_description() -> LaunchDescription:
                 "-0.024086",
                 "--yaw",
                 "-3.1331081",
+                '--ros-args',
+                '--log-level',
+                log_level,
             ],
         ),
     ]
-    return LaunchDescription(nodes)
+    return LaunchDescription([log_level_da] + nodes)

--- a/ada_moveit/calib/manual/calib_camera_pose.launch.py
+++ b/ada_moveit/calib/manual/calib_camera_pose.launch.py
@@ -1,6 +1,8 @@
 """ Static transform publisher acquired via MoveIt 2 hand-eye calibration """
 """ EYE-IN-HAND: j2n6s200_end_effector -> camera_color_optical_frame """
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
@@ -11,6 +13,14 @@ from launch_ros.actions import Node
 # in RVIZ. The transform was then adjusted until the depthcloud
 # visually matched the mesh.
 def generate_launch_description() -> LaunchDescription:
+    # Log Level
+    log_level_da = DeclareLaunchArgument(
+        "log_level",
+        default_value="info",
+        description="Logging level (debug, info, warn, error, fatal)",
+    )
+    log_level = LaunchConfiguration("log_level")
+    
     nodes = [
         Node(
             package="tf2_ros",
@@ -33,7 +43,10 @@ def generate_launch_description() -> LaunchDescription:
                 "0.0",
                 "--yaw",
                 "-3.14",
+                '--ros-args',
+                '--log-level',
+                log_level,
             ],
         ),
     ]
-    return LaunchDescription(nodes)
+    return LaunchDescription([log_level_da] + nodes)

--- a/ada_moveit/calib/ros2/calib_camera_pose.launch.py
+++ b/ada_moveit/calib/ros2/calib_camera_pose.launch.py
@@ -1,10 +1,20 @@
 """ Static transform publisher acquired via MoveIt 2 hand-eye calibration """
 """ EYE-IN-HAND: j2n6s200_end_effector -> camera_color_optical_frame """
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
 def generate_launch_description() -> LaunchDescription:
+    # Log Level
+    log_level_da = DeclareLaunchArgument(
+        "log_level",
+        default_value="info",
+        description="Logging level (debug, info, warn, error, fatal)",
+    )
+    log_level = LaunchConfiguration("log_level")
+    
     nodes = [
         Node(
             package="tf2_ros",
@@ -35,7 +45,10 @@ def generate_launch_description() -> LaunchDescription:
                 # "-0.0374741",
                 # "--yaw",
                 # "2.98455",
+                '--ros-args',
+                '--log-level',
+                log_level,
             ],
         ),
     ]
-    return LaunchDescription(nodes)
+    return LaunchDescription([log_level_da] + nodes)

--- a/ada_moveit/config/ada.srdf
+++ b/ada_moveit/config/ada.srdf
@@ -50,9 +50,8 @@
         <joint name="j2n6s200_joint_finger_1" value="1.46977"/>
         <joint name="j2n6s200_joint_finger_2" value="1.46977"/>
     </group_state>
-    <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
+    <!--END EFFECTOR: Purpose: Delineate group(s) as end-effectors for other group(s).-->
     <end_effector name="hand" parent_link="j2n6s200_link_6" group="hand" parent_group="jaco_arm"/>
-    <end_effector name="forque" parent_link="forkTip" group="jaco_arm"/>
     <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
     <virtual_joint name="world_to_root" type="fixed" parent_frame="world" child_link="root"/>
     <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->

--- a/ada_moveit/launch/demo.launch.py
+++ b/ada_moveit/launch/demo.launch.py
@@ -62,12 +62,21 @@ def generate_launch_description():
     )
     servo_file = LaunchConfiguration("servo_file")
 
+    # Log Level
+    log_level_da = DeclareLaunchArgument(
+        "log_level",
+        default_value="info",
+        description="Logging level (debug, info, warn, error, fatal)",
+    )
+    log_level = LaunchConfiguration("log_level")
+
     # Copy from generate_demo_launch
     ld = LaunchDescription()
     ld.add_action(calib_da)
     ld.add_action(sim_da)
     ld.add_action(ctrl_da)
     ld.add_action(servo_da)
+    ld.add_action(log_level_da)
 
     # Camera Calibration File
     ld.add_action(
@@ -84,6 +93,9 @@ def generate_launch_description():
                     )
                 ]
             ),
+            launch_arguments={
+                "log_level": log_level,
+            }.items(),
         )
     )
 
@@ -96,6 +108,7 @@ def generate_launch_description():
             ),
             launch_arguments={
                 "sim": sim,
+                "log_level": log_level,
             }.items(),
         ),
     )
@@ -124,6 +137,9 @@ def generate_launch_description():
         ld.add_action(
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource(str(virtual_joints_launch)),
+                launch_arguments={
+                    "log_level": log_level,
+                }.items(),
             )
         )
 
@@ -133,6 +149,9 @@ def generate_launch_description():
             PythonLaunchDescriptionSource(
                 str(moveit_config.package_path / "launch/rsp.launch.py")
             ),
+            launch_arguments={
+                "log_level": log_level,
+            }.items(),
         )
     )
 
@@ -144,6 +163,7 @@ def generate_launch_description():
             ),
             launch_arguments={
                 "sim": sim,
+                "log_level": log_level,
             }.items(),
         )
     )
@@ -154,6 +174,9 @@ def generate_launch_description():
             PythonLaunchDescriptionSource(
                 str(moveit_config.package_path / "launch/moveit_rviz.launch.py")
             ),
+            launch_arguments={
+                "log_level": log_level,
+            }.items(),
             condition=IfCondition(LaunchConfiguration("use_rviz")),
         )
     )
@@ -164,6 +187,9 @@ def generate_launch_description():
             PythonLaunchDescriptionSource(
                 str(moveit_config.package_path / "launch/warehouse_db.launch.py")
             ),
+            launch_arguments={
+                "log_level": log_level,
+            }.items(),
             condition=IfCondition(LaunchConfiguration("db")),
         )
     )
@@ -201,6 +227,7 @@ def generate_launch_description():
                 moveit_config.robot_description_kinematics,  # If set, use IK instead of the inverse jacobian
             ],
             output="screen",
+            arguments=['--ros-args', '--log-level', log_level],
         )
     )
 
@@ -214,6 +241,7 @@ def generate_launch_description():
             package="controller_manager",
             executable="ros2_control_node",
             parameters=[robot_description, robot_controllers],
+            arguments=['--ros-args', '--log-level', log_level],
         )
     )
 
@@ -222,6 +250,9 @@ def generate_launch_description():
             PythonLaunchDescriptionSource(
                 str(moveit_config.package_path / "launch/spawn_controllers.launch.py")
             ),
+            launch_arguments={
+                "log_level": log_level,
+            }.items(),
         )
     )
 

--- a/ada_moveit/launch/demo.launch.py
+++ b/ada_moveit/launch/demo.launch.py
@@ -142,6 +142,9 @@ def generate_launch_description():
             PythonLaunchDescriptionSource(
                 str(moveit_config.package_path / "launch/move_group.launch.py")
             ),
+            launch_arguments={
+                "sim": sim,
+            }.items(),
         )
     )
 

--- a/ada_moveit/launch/move_group.launch.py
+++ b/ada_moveit/launch/move_group.launch.py
@@ -1,9 +1,40 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
+from launch.substitutions import LaunchConfiguration
 from moveit_configs_utils import MoveItConfigsBuilder
 from moveit_configs_utils.launches import generate_move_group_launch
 
+def get_move_group_launch(context):
+    """
+    Gets the launch description for MoveGroup, after removing sensors_3d
+    if sim is mock.
 
-def generate_launch_description():
+    Adapted from https://robotics.stackexchange.com/questions/104340/getting-the-value-of-launchargument-inside-python-launch-file
+    """
+    sim = LaunchConfiguration("sim").perform(context)
+
+    # Get MoveIt Configs
     moveit_config = MoveItConfigsBuilder(
         "ada", package_name="ada_moveit"
     ).to_moveit_configs()
-    return generate_move_group_launch(moveit_config)
+
+    # If sim is mock, set moveit_config.sensors_3d to an empty dictionary
+    if sim == "mock":
+        moveit_config.sensors_3d = {}
+
+    return generate_move_group_launch(moveit_config).entities
+
+def generate_launch_description():
+    # Sim Launch Argument
+    sim_da = DeclareLaunchArgument(
+        "sim",
+        default_value="real",
+        description="Which sim to use: 'mock', 'isaac', or 'real'",
+    )
+
+    ld = LaunchDescription()
+    ld.add_action(sim_da)
+    ld.add_action(
+        OpaqueFunction(function=get_move_group_launch)
+    )
+    return ld

--- a/ada_moveit/launch/moveit_rviz.launch.py
+++ b/ada_moveit/launch/moveit_rviz.launch.py
@@ -1,9 +1,32 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch.utilities import normalize_to_list_of_substitutions
+from launch_ros.actions import Node
 from moveit_configs_utils import MoveItConfigsBuilder
 from moveit_configs_utils.launches import generate_moveit_rviz_launch
 
 
 def generate_launch_description():
+
+    ld = LaunchDescription()
+    # Log Level
+    log_level_da = DeclareLaunchArgument(
+        "log_level",
+        default_value="info",
+        description="Logging level (debug, info, warn, error, fatal)",
+    )
+    log_level = LaunchConfiguration("log_level")
+    log_level_cmd_line_args = ["--ros-args", "--log-level", log_level]
+    ld.add_action(log_level_da)
+    
     moveit_config = MoveItConfigsBuilder(
         "ada", package_name="ada_moveit"
     ).to_moveit_configs()
-    return generate_moveit_rviz_launch(moveit_config)
+    entities = generate_moveit_rviz_launch(moveit_config).entities
+    for entity in entities:
+        if isinstance(entity, Node):
+            entity.cmd.extend([normalize_to_list_of_substitutions(arg) for arg in log_level_cmd_line_args])
+        ld.add_action(entity)
+
+    return ld

--- a/ada_moveit/launch/rsp.launch.py
+++ b/ada_moveit/launch/rsp.launch.py
@@ -1,9 +1,32 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch.utilities import normalize_to_list_of_substitutions
+from launch_ros.actions import Node
 from moveit_configs_utils import MoveItConfigsBuilder
 from moveit_configs_utils.launches import generate_rsp_launch
 
 
 def generate_launch_description():
+
+    ld = LaunchDescription()
+    # Log Level
+    log_level_da = DeclareLaunchArgument(
+        "log_level",
+        default_value="info",
+        description="Logging level (debug, info, warn, error, fatal)",
+    )
+    log_level = LaunchConfiguration("log_level")
+    log_level_cmd_line_args = ["--ros-args", "--log-level", log_level]
+    ld.add_action(log_level_da)
+    
     moveit_config = MoveItConfigsBuilder(
         "ada", package_name="ada_moveit"
     ).to_moveit_configs()
-    return generate_rsp_launch(moveit_config)
+    entities = generate_rsp_launch(moveit_config).entities
+    for entity in entities:
+        if isinstance(entity, Node):
+            entity.cmd.extend([normalize_to_list_of_substitutions(arg) for arg in log_level_cmd_line_args])
+        ld.add_action(entity)
+
+    return ld

--- a/ada_moveit/launch/setup_assistant.launch.py
+++ b/ada_moveit/launch/setup_assistant.launch.py
@@ -1,9 +1,32 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch.utilities import normalize_to_list_of_substitutions
+from launch_ros.actions import Node
 from moveit_configs_utils import MoveItConfigsBuilder
 from moveit_configs_utils.launches import generate_setup_assistant_launch
 
 
 def generate_launch_description():
+
+    ld = LaunchDescription()
+    # Log Level
+    log_level_da = DeclareLaunchArgument(
+        "log_level",
+        default_value="info",
+        description="Logging level (debug, info, warn, error, fatal)",
+    )
+    log_level = LaunchConfiguration("log_level")
+    log_level_cmd_line_args = ["--ros-args", "--log-level", log_level]
+    ld.add_action(log_level_da)
+
     moveit_config = MoveItConfigsBuilder(
         "ada", package_name="ada_moveit"
     ).to_moveit_configs()
-    return generate_setup_assistant_launch(moveit_config)
+    entities = generate_setup_assistant_launch(moveit_config).entities
+    for entity in entities:
+        if isinstance(entity, Node):
+            entity.cmd.extend([normalize_to_list_of_substitutions(arg) for arg in log_level_cmd_line_args])
+        ld.add_action(entity)
+
+    return ld

--- a/ada_moveit/launch/spawn_controllers.launch.py
+++ b/ada_moveit/launch/spawn_controllers.launch.py
@@ -1,9 +1,32 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch.utilities import normalize_to_list_of_substitutions
+from launch_ros.actions import Node
 from moveit_configs_utils import MoveItConfigsBuilder
 from moveit_configs_utils.launches import generate_spawn_controllers_launch
 
 
 def generate_launch_description():
+
+    ld = LaunchDescription()
+    # Log Level
+    log_level_da = DeclareLaunchArgument(
+        "log_level",
+        default_value="info",
+        description="Logging level (debug, info, warn, error, fatal)",
+    )
+    log_level = LaunchConfiguration("log_level")
+    log_level_cmd_line_args = ["--ros-args", "--log-level", log_level]
+    ld.add_action(log_level_da)
+    
     moveit_config = MoveItConfigsBuilder(
         "ada", package_name="ada_moveit"
     ).to_moveit_configs()
-    return generate_spawn_controllers_launch(moveit_config)
+    entities = generate_spawn_controllers_launch(moveit_config).entities
+    for entity in entities:
+        if isinstance(entity, Node):
+            entity.cmd.extend([normalize_to_list_of_substitutions(arg) for arg in log_level_cmd_line_args])
+        ld.add_action(entity)
+
+    return ld

--- a/ada_moveit/launch/static_virtual_joint_tfs.launch.py
+++ b/ada_moveit/launch/static_virtual_joint_tfs.launch.py
@@ -1,9 +1,32 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch.utilities import normalize_to_list_of_substitutions
+from launch_ros.actions import Node
 from moveit_configs_utils import MoveItConfigsBuilder
 from moveit_configs_utils.launches import generate_static_virtual_joint_tfs_launch
 
 
 def generate_launch_description():
+
+    ld = LaunchDescription()
+    # Log Level
+    log_level_da = DeclareLaunchArgument(
+        "log_level",
+        default_value="info",
+        description="Logging level (debug, info, warn, error, fatal)",
+    )
+    log_level = LaunchConfiguration("log_level")
+    log_level_cmd_line_args = ["--ros-args", "--log-level", log_level]
+    ld.add_action(log_level_da)
+    
     moveit_config = MoveItConfigsBuilder(
         "ada", package_name="ada_moveit"
     ).to_moveit_configs()
-    return generate_static_virtual_joint_tfs_launch(moveit_config)
+    entities = generate_static_virtual_joint_tfs_launch(moveit_config).entities
+    for entity in entities:
+        if isinstance(entity, Node):
+            entity.cmd.extend([normalize_to_list_of_substitutions(arg) for arg in log_level_cmd_line_args])
+        ld.add_action(entity)
+
+    return ld

--- a/ada_moveit/launch/warehouse_db.launch.py
+++ b/ada_moveit/launch/warehouse_db.launch.py
@@ -1,9 +1,32 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch.utilities import normalize_to_list_of_substitutions
+from launch_ros.actions import Node
 from moveit_configs_utils import MoveItConfigsBuilder
 from moveit_configs_utils.launches import generate_warehouse_db_launch
 
 
 def generate_launch_description():
+
+    ld = LaunchDescription()
+    # Log Level
+    log_level_da = DeclareLaunchArgument(
+        "log_level",
+        default_value="info",
+        description="Logging level (debug, info, warn, error, fatal)",
+    )
+    log_level = LaunchConfiguration("log_level")
+    log_level_cmd_line_args = ["--ros-args", "--log-level", log_level]
+    ld.add_action(log_level_da)
+    
     moveit_config = MoveItConfigsBuilder(
         "ada", package_name="ada_moveit"
     ).to_moveit_configs()
-    return generate_warehouse_db_launch(moveit_config)
+    entities = generate_warehouse_db_launch(moveit_config).entities
+    for entity in entities:
+        if isinstance(entity, Node):
+            entity.cmd.extend([normalize_to_list_of_substitutions(arg) for arg in log_level_cmd_line_args])
+        ld.add_action(entity)
+
+    return ld


### PR DESCRIPTION
# Description

This PR does two things:

1. The SRDF had an `end_effector` that wasn't and couldn't be used, because there is no appropriate group to specify as a parent group (see here for details on [how that SRDF tag is parsed](https://github.com/ros-planning/moveit2/blob/43c5f6d03e423b53afa3a27f659adf2e6c3f4b5b/moveit_core/robot_model/src/robot_model.cpp#L629), and here for [details about the intent of that SRDF tag](https://moveit.picknik.ai/humble/doc/examples/urdf_srdf/urdf_srdf_tutorial.html#end-effectors)). This PR removes that unnecessary SRDF tag.
2. Although MoveIt2 nodes use a variety of log levels, there is currently no convenient way to set the log levels across all the nodes launched in the MoveIt2 ecosystem. This PR is one way to address that, although a more succinct way is proposed in [`moveit2`#2770](https://github.com/ros-planning/moveit2/issues/2770).

# Testing

- [x] Launch the code: `ros2 launch ada_moveit demo.launch.py sim:=mock`. Earlier, a warning used to appear `Could not identify parent from for end-effector 'forque'`; that warning should no longer appear.
- [x] Launch the code with log level error: `ros2 launch ada_moveit demo.launch.py sim:=mock log_level:=error`. Verify that other than the launch process logs, and the MoveGroup logs that don't go through ROS logging, all other logs are only error-level.
- [x] Launch the code with log level debug: `ros2 launch ada_moveit demo.launch.py sim:=mock log_level:=debug`. Verify that you see all logs debug and up in severity.