### PR TITLE
Implement Web App Teleop & Arm Configuration Customization

### DIFF
--- a/ada_imu/launch/ada_imu.launch.py
+++ b/ada_imu/launch/ada_imu.launch.py
@@ -44,7 +44,7 @@ def generate_launch_description():
         name="imu_jointstate_publisher",
         executable="imu_jointstate_publisher",
         parameters=[config, sim_param],
-        arguments=['--ros-args', '--log-level', log_level],
+        arguments=["--ros-args", "--log-level", log_level],
     )
 
     launch_description.add_action(imu_jointstate_publisher)

--- a/ada_moveit/CMakeLists.txt
+++ b/ada_moveit/CMakeLists.txt
@@ -9,6 +9,7 @@ ament_python_install_package(${PROJECT_NAME})
 # Install Python executables
 install(PROGRAMS
   scripts/ada_keyboard_teleop.py
+  scripts/servo_republisher.py
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/ada_moveit/calib/autocalib/calib_camera_pose.launch.py
+++ b/ada_moveit/calib/autocalib/calib_camera_pose.launch.py
@@ -14,7 +14,7 @@ def generate_launch_description() -> LaunchDescription:
         description="Logging level (debug, info, warn, error, fatal)",
     )
     log_level = LaunchConfiguration("log_level")
-    
+
     nodes = [
         Node(
             package="tf2_ros",
@@ -39,8 +39,8 @@ def generate_launch_description() -> LaunchDescription:
                 "-0.0876462",
                 "--qw",
                 "-0.0959528",
-                '--ros-args',
-                '--log-level',
+                "--ros-args",
+                "--log-level",
                 log_level,
             ],
         ),

--- a/ada_moveit/calib/default/calib1/camera_calib_pose.launch.py
+++ b/ada_moveit/calib/default/calib1/camera_calib_pose.launch.py
@@ -14,7 +14,7 @@ def generate_launch_description() -> LaunchDescription:
         description="Logging level (debug, info, warn, error, fatal)",
     )
     log_level = LaunchConfiguration("log_level")
-    
+
     nodes = [
         Node(
             package="tf2_ros",
@@ -45,8 +45,8 @@ def generate_launch_description() -> LaunchDescription:
                 # "-0.00166814",
                 # "--yaw",
                 # "-3.13232",
-                '--ros-args',
-                '--log-level',
+                "--ros-args",
+                "--log-level",
                 log_level,
             ],
         ),

--- a/ada_moveit/calib/default/calib2/camera_calib_pose.launch.py
+++ b/ada_moveit/calib/default/calib2/camera_calib_pose.launch.py
@@ -14,7 +14,7 @@ def generate_launch_description() -> LaunchDescription:
         description="Logging level (debug, info, warn, error, fatal)",
     )
     log_level = LaunchConfiguration("log_level")
-    
+
     nodes = [
         Node(
             package="tf2_ros",
@@ -45,8 +45,8 @@ def generate_launch_description() -> LaunchDescription:
                 # "0.00241343",
                 # "--yaw",
                 # "3.13318",
-                '--ros-args',
-                '--log-level',
+                "--ros-args",
+                "--log-level",
                 log_level,
             ],
         ),

--- a/ada_moveit/calib/default/calib_camera_pose.launch.py
+++ b/ada_moveit/calib/default/calib_camera_pose.launch.py
@@ -7,7 +7,7 @@ from launch_ros.actions import Node
 
 
 def generate_launch_description() -> LaunchDescription:
-     # Log Level
+    # Log Level
     log_level_da = DeclareLaunchArgument(
         "log_level",
         default_value="info",
@@ -37,8 +37,8 @@ def generate_launch_description() -> LaunchDescription:
                 "-0.024086",
                 "--yaw",
                 "-3.1331081",
-                '--ros-args',
-                '--log-level',
+                "--ros-args",
+                "--log-level",
                 log_level,
             ],
         ),

--- a/ada_moveit/calib/manual/calib_camera_pose.launch.py
+++ b/ada_moveit/calib/manual/calib_camera_pose.launch.py
@@ -20,7 +20,7 @@ def generate_launch_description() -> LaunchDescription:
         description="Logging level (debug, info, warn, error, fatal)",
     )
     log_level = LaunchConfiguration("log_level")
-    
+
     nodes = [
         Node(
             package="tf2_ros",
@@ -43,8 +43,8 @@ def generate_launch_description() -> LaunchDescription:
                 "0.0",
                 "--yaw",
                 "-3.14",
-                '--ros-args',
-                '--log-level',
+                "--ros-args",
+                "--log-level",
                 log_level,
             ],
         ),

--- a/ada_moveit/calib/ros2/calib_camera_pose.launch.py
+++ b/ada_moveit/calib/ros2/calib_camera_pose.launch.py
@@ -14,7 +14,7 @@ def generate_launch_description() -> LaunchDescription:
         description="Logging level (debug, info, warn, error, fatal)",
     )
     log_level = LaunchConfiguration("log_level")
-    
+
     nodes = [
         Node(
             package="tf2_ros",
@@ -45,8 +45,8 @@ def generate_launch_description() -> LaunchDescription:
                 # "-0.0374741",
                 # "--yaw",
                 # "2.98455",
-                '--ros-args',
-                '--log-level',
+                "--ros-args",
+                "--log-level",
                 log_level,
             ],
         ),

--- a/ada_moveit/config/real_controllers.yaml
+++ b/ada_moveit/config/real_controllers.yaml
@@ -37,7 +37,7 @@ jaco_arm_cartesian_controller:
         - velocity
       solver:
         damped_least_squares:
-          alpha: 0.01
+          alpha: 0.001
       wrench_threshold:
         topic: /wireless_ft/ftSensor3
         fMag: 1.0

--- a/ada_moveit/launch/demo.launch.py
+++ b/ada_moveit/launch/demo.launch.py
@@ -227,7 +227,7 @@ def generate_launch_description():
                 moveit_config.robot_description_kinematics,  # If set, use IK instead of the inverse jacobian
             ],
             output="screen",
-            arguments=['--ros-args', '--log-level', log_level],
+            arguments=["--ros-args", "--log-level", log_level],
         )
     )
 
@@ -241,7 +241,7 @@ def generate_launch_description():
             package="controller_manager",
             executable="ros2_control_node",
             parameters=[robot_description, robot_controllers],
-            arguments=['--ros-args', '--log-level', log_level],
+            arguments=["--ros-args", "--log-level", log_level],
         )
     )
 

--- a/ada_moveit/launch/move_group.launch.py
+++ b/ada_moveit/launch/move_group.launch.py
@@ -7,6 +7,7 @@ from launch.substitutions import LaunchConfiguration
 from moveit_configs_utils import MoveItConfigsBuilder
 from moveit_configs_utils.launches import generate_move_group_launch
 
+
 def get_move_group_launch(context):
     """
     Gets the launch description for MoveGroup, after removing sensors_3d
@@ -30,8 +31,14 @@ def get_move_group_launch(context):
     log_level_cmd_line_args = ["--ros-args", "--log-level", log_level]
     for entity in entities:
         if isinstance(entity, Node):
-            entity.cmd.extend([normalize_to_list_of_substitutions(arg) for arg in log_level_cmd_line_args])
+            entity.cmd.extend(
+                [
+                    normalize_to_list_of_substitutions(arg)
+                    for arg in log_level_cmd_line_args
+                ]
+            )
     return entities
+
 
 def generate_launch_description():
     # Sim Launch Argument
@@ -50,7 +57,5 @@ def generate_launch_description():
     ld = LaunchDescription()
     ld.add_action(sim_da)
     ld.add_action(log_level_da)
-    ld.add_action(
-        OpaqueFunction(function=get_move_group_launch)
-    )
+    ld.add_action(OpaqueFunction(function=get_move_group_launch))
     return ld

--- a/ada_moveit/launch/moveit_rviz.launch.py
+++ b/ada_moveit/launch/moveit_rviz.launch.py
@@ -8,7 +8,6 @@ from moveit_configs_utils.launches import generate_moveit_rviz_launch
 
 
 def generate_launch_description():
-
     ld = LaunchDescription()
     # Log Level
     log_level_da = DeclareLaunchArgument(
@@ -19,14 +18,19 @@ def generate_launch_description():
     log_level = LaunchConfiguration("log_level")
     log_level_cmd_line_args = ["--ros-args", "--log-level", log_level]
     ld.add_action(log_level_da)
-    
+
     moveit_config = MoveItConfigsBuilder(
         "ada", package_name="ada_moveit"
     ).to_moveit_configs()
     entities = generate_moveit_rviz_launch(moveit_config).entities
     for entity in entities:
         if isinstance(entity, Node):
-            entity.cmd.extend([normalize_to_list_of_substitutions(arg) for arg in log_level_cmd_line_args])
+            entity.cmd.extend(
+                [
+                    normalize_to_list_of_substitutions(arg)
+                    for arg in log_level_cmd_line_args
+                ]
+            )
         ld.add_action(entity)
 
     return ld

--- a/ada_moveit/launch/rsp.launch.py
+++ b/ada_moveit/launch/rsp.launch.py
@@ -8,7 +8,6 @@ from moveit_configs_utils.launches import generate_rsp_launch
 
 
 def generate_launch_description():
-
     ld = LaunchDescription()
     # Log Level
     log_level_da = DeclareLaunchArgument(
@@ -19,14 +18,19 @@ def generate_launch_description():
     log_level = LaunchConfiguration("log_level")
     log_level_cmd_line_args = ["--ros-args", "--log-level", log_level]
     ld.add_action(log_level_da)
-    
+
     moveit_config = MoveItConfigsBuilder(
         "ada", package_name="ada_moveit"
     ).to_moveit_configs()
     entities = generate_rsp_launch(moveit_config).entities
     for entity in entities:
         if isinstance(entity, Node):
-            entity.cmd.extend([normalize_to_list_of_substitutions(arg) for arg in log_level_cmd_line_args])
+            entity.cmd.extend(
+                [
+                    normalize_to_list_of_substitutions(arg)
+                    for arg in log_level_cmd_line_args
+                ]
+            )
         ld.add_action(entity)
 
     return ld

--- a/ada_moveit/launch/setup_assistant.launch.py
+++ b/ada_moveit/launch/setup_assistant.launch.py
@@ -8,7 +8,6 @@ from moveit_configs_utils.launches import generate_setup_assistant_launch
 
 
 def generate_launch_description():
-
     ld = LaunchDescription()
     # Log Level
     log_level_da = DeclareLaunchArgument(
@@ -26,7 +25,12 @@ def generate_launch_description():
     entities = generate_setup_assistant_launch(moveit_config).entities
     for entity in entities:
         if isinstance(entity, Node):
-            entity.cmd.extend([normalize_to_list_of_substitutions(arg) for arg in log_level_cmd_line_args])
+            entity.cmd.extend(
+                [
+                    normalize_to_list_of_substitutions(arg)
+                    for arg in log_level_cmd_line_args
+                ]
+            )
         ld.add_action(entity)
 
     return ld

--- a/ada_moveit/launch/spawn_controllers.launch.py
+++ b/ada_moveit/launch/spawn_controllers.launch.py
@@ -8,7 +8,6 @@ from moveit_configs_utils.launches import generate_spawn_controllers_launch
 
 
 def generate_launch_description():
-
     ld = LaunchDescription()
     # Log Level
     log_level_da = DeclareLaunchArgument(
@@ -19,14 +18,19 @@ def generate_launch_description():
     log_level = LaunchConfiguration("log_level")
     log_level_cmd_line_args = ["--ros-args", "--log-level", log_level]
     ld.add_action(log_level_da)
-    
+
     moveit_config = MoveItConfigsBuilder(
         "ada", package_name="ada_moveit"
     ).to_moveit_configs()
     entities = generate_spawn_controllers_launch(moveit_config).entities
     for entity in entities:
         if isinstance(entity, Node):
-            entity.cmd.extend([normalize_to_list_of_substitutions(arg) for arg in log_level_cmd_line_args])
+            entity.cmd.extend(
+                [
+                    normalize_to_list_of_substitutions(arg)
+                    for arg in log_level_cmd_line_args
+                ]
+            )
         ld.add_action(entity)
 
     return ld

--- a/ada_moveit/launch/static_virtual_joint_tfs.launch.py
+++ b/ada_moveit/launch/static_virtual_joint_tfs.launch.py
@@ -8,7 +8,6 @@ from moveit_configs_utils.launches import generate_static_virtual_joint_tfs_laun
 
 
 def generate_launch_description():
-
     ld = LaunchDescription()
     # Log Level
     log_level_da = DeclareLaunchArgument(
@@ -19,14 +18,19 @@ def generate_launch_description():
     log_level = LaunchConfiguration("log_level")
     log_level_cmd_line_args = ["--ros-args", "--log-level", log_level]
     ld.add_action(log_level_da)
-    
+
     moveit_config = MoveItConfigsBuilder(
         "ada", package_name="ada_moveit"
     ).to_moveit_configs()
     entities = generate_static_virtual_joint_tfs_launch(moveit_config).entities
     for entity in entities:
         if isinstance(entity, Node):
-            entity.cmd.extend([normalize_to_list_of_substitutions(arg) for arg in log_level_cmd_line_args])
+            entity.cmd.extend(
+                [
+                    normalize_to_list_of_substitutions(arg)
+                    for arg in log_level_cmd_line_args
+                ]
+            )
         ld.add_action(entity)
 
     return ld

--- a/ada_moveit/launch/warehouse_db.launch.py
+++ b/ada_moveit/launch/warehouse_db.launch.py
@@ -8,7 +8,6 @@ from moveit_configs_utils.launches import generate_warehouse_db_launch
 
 
 def generate_launch_description():
-
     ld = LaunchDescription()
     # Log Level
     log_level_da = DeclareLaunchArgument(
@@ -19,14 +18,19 @@ def generate_launch_description():
     log_level = LaunchConfiguration("log_level")
     log_level_cmd_line_args = ["--ros-args", "--log-level", log_level]
     ld.add_action(log_level_da)
-    
+
     moveit_config = MoveItConfigsBuilder(
         "ada", package_name="ada_moveit"
     ).to_moveit_configs()
     entities = generate_warehouse_db_launch(moveit_config).entities
     for entity in entities:
         if isinstance(entity, Node):
-            entity.cmd.extend([normalize_to_list_of_substitutions(arg) for arg in log_level_cmd_line_args])
+            entity.cmd.extend(
+                [
+                    normalize_to_list_of_substitutions(arg)
+                    for arg in log_level_cmd_line_args
+                ]
+            )
         ld.add_action(entity)
 
     return ld

--- a/ada_moveit/package.xml
+++ b/ada_moveit/package.xml
@@ -37,7 +37,6 @@
   <exec_depend>moveit_ros_visualization</exec_depend>
   <exec_depend>moveit_ros_warehouse</exec_depend>
   <exec_depend>moveit_setup_assistant</exec_depend>
-  <exec_depend>pick_ik</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>ros2_control</exec_depend>
   <exec_depend>ros2_controllers</exec_depend>

--- a/ada_moveit/scripts/servo_republisher.py
+++ b/ada_moveit/scripts/servo_republisher.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+This module defines the ServoRepublisher node, which listens for servo commands
+(either TwistStamped or JointJog) on input topics, and republishes them on output
+topics with the following modifications:
+  1. The header timestamp is replaced with the current time. This is useful if
+     the device sending the servo commands (e.g., a personal smartphone) does not
+     have a clock that is synchronized to the robot's clock.
+  2. For cartesian TwistStamped commands, this script interprets the linear velocity
+     in the **base frame** of the robot and angular velocity in the **end effector
+     frame** of the robot. It transforms both to the **base frame** before republishing.
+"""
+
+# Standard imports
+from typing import List
+
+# Third-party imports
+from control_msgs.msg import JointJog
+from geometry_msgs.msg import TwistStamped
+from rcl_interfaces.msg import ParameterDescriptor, ParameterType
+import rclpy
+from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.node import Node
+from tf2_geometry_msgs import Vector3Stamped
+from tf2_ros.buffer import Buffer
+from tf2_ros.transform_listener import TransformListener
+
+# Local imports
+
+
+class ServoRepublisher(Node):
+    """
+    This class defines the ServoRepublisher node, which listens for servo commands
+    (either TwistStamped or JointJog) on input topics, and republishes them on output
+    topics with the following modifications:
+    1. The header timestamp is replaced with the current time. This is useful if
+        the device sending the servo commands (e.g., a personal smartphone) does not
+        have a clock that is synchronized to the robot's clock.
+    2. For cartesian TwistStamped commands, this script interprets the linear velocity
+        in the **base frame** of the robot and angular velocity in the **end effector
+        frame** of the robot. It transforms both to the **base frame** before republishing.
+    """
+    def __init__(self):
+        """
+        Initialize the node.
+        """
+        # pylint: disable=too-many-instance-attributes
+        # This number is fine because we need to maintain references to all pubs/subs
+        super().__init__("servo_republisher")
+
+        # Read the parameters
+        self.read_params()
+
+        # Create the TF buffer and listener
+        self.tf_buffer = Buffer()
+        self.tf_listener = TransformListener(self.tf_buffer, self)
+
+        # Create the publishers
+        self.cartesian_output_pub = self.create_publisher(
+            TwistStamped, "~/cartesian_commands_output", 1
+        )
+        self.joint_output_pub = self.create_publisher(
+            JointJog, "~/joint_commands_output", 1
+        )
+
+        # Create the subscribers
+        self.cartesian_input_sub = self.create_subscription(
+            TwistStamped,
+            "~/cartesian_commands_input",
+            self.cartesian_input_callback,
+            1,
+            callback_group=MutuallyExclusiveCallbackGroup(),
+        )
+        self.joint_input_sub = self.create_subscription(
+            JointJog,
+            "~/joint_commands_input",
+            self.joint_input_callback,
+            1,
+            callback_group=MutuallyExclusiveCallbackGroup(),
+        )
+
+    def read_params(self):
+        """
+        Read parameters from the ROS 2 parameter server.
+        """
+        # pylint: disable=attribute-defined-outside-init
+        input_linear_velocity_frame = self.declare_parameter(
+            "input_linear_velocity_frame",
+            "j2n6s200_link_base",
+            descriptor=ParameterDescriptor(
+                name="input_linear_velocity_frame",
+                type=ParameterType.PARAMETER_STRING,
+                description=(
+                    "The frame in which the input linear velocity is interpreted."
+                ),
+                read_only=True,
+            ),
+        ).value
+        self.linear_velocity = Vector3Stamped()
+        self.linear_velocity.header.frame_id = input_linear_velocity_frame
+        input_angular_velocity_frame = self.declare_parameter(
+            "input_angular_velocity_frame",
+            "forkTip",
+            descriptor=ParameterDescriptor(
+                name="input_angular_velocity_frame",
+                type=ParameterType.PARAMETER_STRING,
+                description=(
+                    "The frame in which the input angular velocity is interpreted."
+                ),
+                read_only=True,
+            ),
+        ).value
+        self.angular_velocity = Vector3Stamped()
+        self.angular_velocity.header.frame_id = input_angular_velocity_frame
+        output_twist_frame = self.declare_parameter(
+            "output_twist_frame",
+            "j2n6s200_link_base",
+            descriptor=ParameterDescriptor(
+                name="output_twist_frame",
+                type=ParameterType.PARAMETER_STRING,
+                description=("The frame in which the output twist is published."),
+                read_only=True,
+            ),
+        ).value
+        self.output_twist = TwistStamped()
+        self.output_twist.header.frame_id = output_twist_frame
+
+    def cartesian_input_callback(self, msg: TwistStamped):
+        """
+        Callback for the cartesian input subscriber. Transform the frames,
+        update the timestamp, and republish.
+        """
+        # Transform the linear velocity to the base frame
+        self.linear_velocity.vector = msg.twist.linear
+        if (
+            self.linear_velocity.header.frame_id
+            == self.output_twist.header.frame_id
+        ):
+            final_linear_velocity = self.linear_velocity
+        else:
+            final_linear_velocity = self.tf_buffer.transform(
+                self.linear_velocity, self.output_twist.header.frame_id
+            )
+        # Transform the angular velocity to the base frame
+        self.angular_velocity.vector = msg.twist.angular
+        if (
+            self.angular_velocity.header.frame_id
+            == self.output_twist.header.frame_id
+        ):
+            final_angular_velocity = self.angular_velocity
+        else:
+            final_angular_velocity = self.tf_buffer.transform(
+                self.angular_velocity, self.output_twist.header.frame_id
+            )
+
+        # Create the output message
+        self.output_twist.header.stamp = self.get_clock().now().to_msg()
+        self.output_twist.twist.linear = final_linear_velocity.vector
+        self.output_twist.twist.angular = final_angular_velocity.vector
+
+        # Publish the output message
+        self.cartesian_output_pub.publish(self.output_twist)
+
+    def joint_input_callback(self, msg: JointJog):
+        """
+        Callback for the joint input subscriber. Update the timestamp and republish.
+        """
+        msg.header.stamp = self.get_clock().now().to_msg()
+        self.joint_output_pub.publish(msg)
+
+
+def main(args: List = None) -> None:
+    """
+    Create the ROS2 node and run the action servers.
+    """
+    rclpy.init(args=args)
+
+    servo_republisher = ServoRepublisher()
+
+    # Use a MultiThreadedExecutor to enable processing goals concurrently
+    executor = MultiThreadedExecutor(num_threads=2)
+    rclpy.spin(servo_republisher, executor=executor)
+
+    # Destroy the node explicitly
+    servo_republisher.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/ada_moveit/scripts/servo_republisher.py
+++ b/ada_moveit/scripts/servo_republisher.py
@@ -12,21 +12,40 @@ topics with the following modifications:
 """
 
 # Standard imports
+from threading import Lock
 from typing import List
 
 # Third-party imports
 from control_msgs.msg import JointJog
-from geometry_msgs.msg import TwistStamped
+from geometry_msgs.msg import TwistStamped, Vector3
+import numpy as np
 from rcl_interfaces.msg import ParameterDescriptor, ParameterType
+from rcl_interfaces.srv import GetParameters
 import rclpy
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
+from rclpy.duration import Duration
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
+from rclpy.time import Time
+from sensor_msgs.msg import JointState
+from std_msgs.msg import Float64MultiArray
 from tf2_geometry_msgs import Vector3Stamped
 from tf2_ros.buffer import Buffer
 from tf2_ros.transform_listener import TransformListener
 
 # Local imports
+
+
+JOINT_NAMES = [
+    "j2n6s200_joint_1",
+    "j2n6s200_joint_2",
+    "j2n6s200_joint_3",
+    "j2n6s200_joint_4",
+    "j2n6s200_joint_5",
+    "j2n6s200_joint_6",
+]
+POSITION_INTERFACE_NAME = "position"
+VELOCITY_INTERFACE_NAME = "velocity"
 
 
 class ServoRepublisher(Node):
@@ -41,27 +60,57 @@ class ServoRepublisher(Node):
         in the **base frame** of the robot and angular velocity in the **end effector
         frame** of the robot. It transforms both to the **base frame** before republishing.
     """
+
+    # pylint: disable=too-many-instance-attributes
+    # This number is fine because we need to maintain references to all pubs/subs
+
     def __init__(self):
         """
         Initialize the node.
         """
-        # pylint: disable=too-many-instance-attributes
-        # This number is fine because we need to maintain references to all pubs/subs
         super().__init__("servo_republisher")
 
         # Read the parameters
         self.read_params()
 
+        # Determine if the joint controller is position or velocity.
+        self.joint_controller_interface_name = None
+        self.joint_controller_get_parameter = self.create_client(
+            GetParameters,
+            "~/joint_controller_get_parameters",
+            callback_group=MutuallyExclusiveCallbackGroup(),
+        )
+        self.joint_states_sub = None
+        self.latest_joint_states_lock = Lock()
+        self.latest_joint_states = {}
+        self.get_joint_controller_interface_name()
+
         # Create the TF buffer and listener
         self.tf_buffer = Buffer()
         self.tf_listener = TransformListener(self.tf_buffer, self)
+
+        # Create the timer to check for stale messages
+        self.latest_msg_lock = Lock()
+        self.latest_msg = None
+        # In the worst case, the timer can take up to self.servo_timeout_sec +
+        # timer_duration to find a stale message. Thus, we run the timer at a
+        # shorter interval than self.servo_timeout_sec
+        self.stale_msg_timer = self.create_timer(
+            self.servo_timeout_sec / 2.0,
+            self.stale_msg_check,
+            callback_group=MutuallyExclusiveCallbackGroup(),
+        )
+        self.servo_timeout_sec = Duration(seconds=self.servo_timeout_sec)
+
+        # Store the previous joint velocities for the exponential moving average
+        self.prev_joint_velocities = [0.0 for _ in JOINT_NAMES]
 
         # Create the publishers
         self.cartesian_output_pub = self.create_publisher(
             TwistStamped, "~/cartesian_commands_output", 1
         )
         self.joint_output_pub = self.create_publisher(
-            JointJog, "~/joint_commands_output", 1
+            Float64MultiArray, "~/joint_commands_output", 1
         )
 
         # Create the subscribers
@@ -85,6 +134,7 @@ class ServoRepublisher(Node):
         Read parameters from the ROS 2 parameter server.
         """
         # pylint: disable=attribute-defined-outside-init
+        # Parameters for cartesian control
         input_linear_velocity_frame = self.declare_parameter(
             "input_linear_velocity_frame",
             "j2n6s200_link_base",
@@ -126,17 +176,101 @@ class ServoRepublisher(Node):
         self.output_twist = TwistStamped()
         self.output_twist.header.frame_id = output_twist_frame
 
-    def cartesian_input_callback(self, msg: TwistStamped):
+        # Parameters for joint control
+        self.exponential_moving_average_alpha = self.declare_parameter(
+            "exponential_moving_average_alpha",
+            0.5,
+            descriptor=ParameterDescriptor(
+                name="exponential_moving_average_alpha",
+                type=ParameterType.PARAMETER_DOUBLE,
+                description=(
+                    "To smoothen velocities, this node will take the exponential "
+                    "weighted average of the non-zero joint velocities it gets. "
+                    "Zero velocities are sent to the controller without modification. "
+                    "To disable the exponential moving average, set this to 1.0."
+                ),
+                read_only=True,
+            ),
+        ).value
+        if self.exponential_moving_average_alpha < 0.0:
+            self.get_logger().warn("exponential_moving_average_alpha must be >= 0")
+            self.exponential_moving_average_alpha = 0.0
+        if self.exponential_moving_average_alpha > 1.0:
+            self.get_logger().warn("exponential_moving_average_alpha must be <= 1")
+            self.exponential_moving_average_alpha = 1.0
+
+        # Parameters for both cartesian and joint control
+        self.servo_timeout_sec = self.declare_parameter(
+            "servo_timeout_sec",
+            0.33,
+            descriptor=ParameterDescriptor(
+                name="servo_timeout_sec",
+                type=ParameterType.PARAMETER_DOUBLE,
+                description=(
+                    "Stop moving if you haven't received a command in these many "
+                    "seconds."
+                ),
+                read_only=True,
+            ),
+        ).value
+
+    def get_joint_controller_interface_name(
+        self, parameter_name: str = "interface_name"
+    ) -> None:
+        """
+        Gets the interface name of the joint controller, either POSITION_INTERFACE_NAME or
+        VELOCITY_INTERFACE_NAME, by getting that controller's parameter value.
+        """
+        request = GetParameters.Request(
+            names=[parameter_name],
+        )
+        # TODO: Should this be an async service call instead?
+        response = self.joint_controller_get_parameter.call(request)
+        if len(response.values) > 0 and response.values[0].type == 4:
+            if response.values[0].string_value in [
+                POSITION_INTERFACE_NAME,
+                VELOCITY_INTERFACE_NAME,
+            ]:
+                self.joint_controller_interface_name = response.values[0].string_value
+                # If it is a position controller, then subscribe to the joint states
+                if response.values[0].string_value == POSITION_INTERFACE_NAME:
+                    self.joint_states_sub = self.create_subscription(
+                        JointState,
+                        "~/joint_states",
+                        self.joint_state_callback,
+                        1,
+                        callback_group=MutuallyExclusiveCallbackGroup(),
+                    )
+            else:
+                self.get_logger().error(
+                    "This node only supports position or velocity joint controllers. "
+                    "JointJog messages will be ignored."
+                )
+
+    def joint_state_callback(self, msg: JointState) -> None:
+        """
+        Stores the latest joint states.
+        """
+        joint_states = {}
+        for i, name in enumerate(msg.name):
+            position = msg.position[i]
+            joint_states[name] = position
+
+        with self.latest_joint_states_lock:
+            self.latest_joint_states.update(joint_states)
+
+    def cartesian_input_callback(self, msg: TwistStamped) -> None:
         """
         Callback for the cartesian input subscriber. Transform the frames,
         update the timestamp, and republish.
         """
+        # Store the latest message
+        with self.latest_msg_lock:
+            self.latest_msg = msg
+
         # Transform the linear velocity to the base frame
         self.linear_velocity.vector = msg.twist.linear
-        if (
-            self.linear_velocity.header.frame_id
-            == self.output_twist.header.frame_id
-        ):
+        if self.linear_velocity.header.frame_id == self.output_twist.header.frame_id:
             final_linear_velocity = self.linear_velocity
         else:
             final_linear_velocity = self.tf_buffer.transform(
@@ -144,10 +278,7 @@ class ServoRepublisher(Node):
             )
         # Transform the angular velocity to the base frame
         self.angular_velocity.vector = msg.twist.angular
-        if (
-            self.angular_velocity.header.frame_id
-            == self.output_twist.header.frame_id
-        ):
+        if self.angular_velocity.header.frame_id == self.output_twist.header.frame_id:
             final_angular_velocity = self.angular_velocity
         else:
             final_angular_velocity = self.tf_buffer.transform(
@@ -162,12 +293,150 @@ class ServoRepublisher(Node):
         # Publish the output message
         self.cartesian_output_pub.publish(self.output_twist)
 
-    def joint_input_callback(self, msg: JointJog):
+    def joint_input_callback(self, msg: JointJog) -> None:
         """
         Callback for the joint input subscriber. Update the timestamp and republish.
         """
-        msg.header.stamp = self.get_clock().now().to_msg()
-        self.joint_output_pub.publish(msg)
+        # First, determine the interface type of the joint controller
+        if self.joint_controller_interface_name is None:
+            self.get_joint_controller_interface_name()
+            if self.joint_controller_interface_name is None:
+                return
+
+        # Check the message
+        if len(msg.joint_names) == 0:
+            self.get_logger().warn(
+                "Must have a non-empty list of joints in JointJog messages"
+            )
+            return
+        if len(msg.displacements) > 0:
+            self.get_logger().warn(
+                "The node does not support joint displacements. Ignoring them."
+            )
+        if len(msg.velocities) != len(msg.joint_names):
+            self.get_logger().warn(
+                "Velocities and joint_names must have the same length. Will truncate or zero-pad."
+            )
+
+        # Store the latest message
+        with self.latest_msg_lock:
+            self.latest_msg = msg
+
+        # Process the JointJog message
+        curr_joint_velocities = []
+        for i in range(len(JOINT_NAMES)):  # pylint: disable=consider-using-enumerate
+            j = msg.joint_names.find(JOINT_NAMES[i])
+            if j == -1:  # The joint's velocity was unspecified
+                curr_joint_velocities.append(0.0)
+            else:
+                if j < len(msg.velocities):
+                    curr_joint_velocities.append(msg.velocities[j])
+                else:
+                    curr_joint_velocities.append(0.0)
+
+        # Apply the exponential moving average
+        joint_velocities = []
+        if np.all(np.isclose(curr_joint_velocities, 0.0)):
+            joint_velocities = curr_joint_velocities
+        else:
+            joint_velocities = [
+                curr_joint_velocities * self.exponential_moving_average_alpha
+                + self.prev_joint_velocities
+                * (1.0 - self.exponential_moving_average_alpha)
+                for i in range(
+                    len(JOINT_NAMES)
+                )  # pylint: disable=consider-using-enumerate
+            ]
+
+        # Publish the joint_velocities
+        self.publish_joint_velocity(joint_velocities, msg.duration)
+        self.prev_joint_velocities = joint_velocities
+
+    def publish_joint_velocity(
+        self, joint_velocities: List[float], duration_secs: float = 0.0
+    ) -> None:
+        """
+        Publish the specified joint velocities to the controller.
+        Converts them to positions if that is the interface name of the controller.
+        """
+        # At this point, self.joint_controller_interface_name is either POSITION_INTERFACE_NAME
+        # or VELOCITY_INTERFACE_NAME.
+        # We are also guaranteed that we are given velocities equal to the number of joints.
+        if self.joint_controller_interface_name == VELOCITY_INTERFACE_NAME:
+            self.joint_output_pub.publish(Float64MultiArray(data=joint_velocities))
+        else:
+            missing_joint_names = []
+            curr_joint_positions = []
+            with self.latest_joint_states_lock:
+                for joint_name in JOINT_NAMES:
+                    if joint_name in self.latest_joint_states:
+                        curr_joint_positions.append(
+                            self.latest_joint_states[joint_name]
+                        )
+                    else:
+                        missing_joint_names.append(joint_name)
+            if len(missing_joint_names) > 0:
+                self.get_logger().warn(
+                    f"Haven't received joint states for {missing_joint_names}. Ignoring "
+                    "JointJog message."
+                )
+            else:
+                next_joint_positions = [
+                    curr_joint_positions[i] + joint_velocities[i] * duration_secs
+                    for i in range(len(JOINT_NAMES))
+                ]
+                self.joint_output_pub.publish(
+                    Float64MultiArray(data=next_joint_positions)
+                )
+
+    def stale_msg_check(self) -> None:
+        """
+        If it has been over `self.servo_timeout_sec` since the latest message
+        and that message was non-zero, this node publishes a zero message to
+        that topic.
+        """
+        # Get the latest message
+        with self.latest_msg_lock:
+            latest_msg = self.latest_msg
+
+        # If we haven't received a message, continue
+        if latest_msg is None:
+            return
+
+        # If the message is not stale, continue
+        if (
+            self.get_clock().now() - Time.from_msg(latest_msg.header.stamp)
+            < self.servo_timeout_sec
+        ):
+            return
+
+        # If the message is non-zero, publish a zero-message on the corresponding topic.
+        if isinstance(latest_msg, TwistStamped):
+            # pylint: disable=too-many-boolean-expressions
+            if (
+                latest_msg.twist.linear.x != 0.0
+                or latest_msg.twist.linear.y != 0.0
+                or latest_msg.twist.linear.z != 0.0
+                or latest_msg.twist.angular.x != 0.0
+                or latest_msg.twist.angular.y != 0.0
+                or latest_msg.twist.angular.z != 0.0
+            ):
+                # Publish a zero-velocity message
+                self.output_twist.twist.linear = Vector3(x=0.0, y=0.0, z=0.0)
+                self.output_twist.twist.angular = Vector3(x=0.0, y=0.0, z=0.0)
+                self.cartesian_output_pub.publish(self.output_twist)
+        elif isinstance(latest_msg, JointJog):
+            if len(latest_msg.velocities) != len(JOINT_NAMES) or not np.all(
+                np.isclose(latest_msg.velocities, 0.0)
+            ):
+                # Publish a zero-velocity message
+                self.publish_joint_velocity(JOINT_NAMES, [0.0 for _ in JOINT_NAMES])
+                self.prev_joint_velocities = [0.0 for _ in JOINT_NAMES]
+
+        # Once the zero-message is send, reset the latest_msg
+        with self.latest_msg_lock:
+            if self.latest_msg == latest_msg:
+                self.latest_msg = None
 
 
 def main(args: List = None) -> None:
@@ -179,7 +448,7 @@ def main(args: List = None) -> None:
     servo_republisher = ServoRepublisher()
 
     # Use a MultiThreadedExecutor to enable processing goals concurrently
-    executor = MultiThreadedExecutor(num_threads=2)
+    executor = MultiThreadedExecutor(num_threads=4)
     rclpy.spin(servo_republisher, executor=executor)
 
     # Destroy the node explicitly


### PR DESCRIPTION
# Description

This PR, coupled with [`feeding_web_interface`#133](https://github.com/personalrobotics/feeding_web_interface/pull/133) and [`ada_feeding`#175](https://github.com/personalrobotics/ada_feeding/pull/175), implements a web-app teleop interface for the robot, along with the ability to customize the "Above Plate" configuration using the web app.

Specifically, this PR makes the following changes:

1. Add a servo republisher that receives servo messages from the web app, updates the timestamp (in case the web app device is out-of-sync with the robot time), and modifies the frames of end effector twists.
2. Removes the pick_ik dependency, as now we are using [our fork of pick_ik](https://github.com/personalrobotics/pick_ik/tree/amaln/tip_frames_fix).
3. Formatting

# Testing procedure

Tests are described in [`feeding_web_interface`#133](https://github.com/personalrobotics/feeding_web_interface/pull/133).