### PR TITLE
Move cartesian controller to selectively damped least squares solver

### DIFF
--- a/ada_moveit/config/mock_controllers.yaml
+++ b/ada_moveit/config/mock_controllers.yaml
@@ -25,7 +25,7 @@ jaco_arm_cartesian_controller:
     ros__parameters:
       end_effector_link: "forkTip"
       robot_base_link: "j2n6s200_link_base"
-      ik_solver: "damped_least_squares"
+      ik_solver: "selectively_damped_least_squares"
       joints:
         - j2n6s200_joint_1
         - j2n6s200_joint_2
@@ -35,9 +35,6 @@ jaco_arm_cartesian_controller:
         - j2n6s200_joint_6
       command_interfaces:
         - position
-      solver:
-        damped_least_squares:
-          alpha: 0.01
 
 jaco_arm_controller:
   ros__parameters:

--- a/ada_moveit/config/real_controllers.yaml
+++ b/ada_moveit/config/real_controllers.yaml
@@ -35,9 +35,6 @@ jaco_arm_cartesian_controller:
         - j2n6s200_joint_6
       command_interfaces:
         - velocity
-      # solver:
-      #   damped_least_squares:
-      #     alpha: 0.001
       wrench_threshold:
         topic: /wireless_ft/ftSensor3
         fMag: 1.0

--- a/ada_moveit/config/real_controllers.yaml
+++ b/ada_moveit/config/real_controllers.yaml
@@ -25,7 +25,7 @@ jaco_arm_cartesian_controller:
     ros__parameters:
       end_effector_link: "forkTip"
       robot_base_link: "j2n6s200_link_base"
-      ik_solver: "damped_least_squares"
+      ik_solver: "selectively_damped_least_squares"
       joints:
         - j2n6s200_joint_1
         - j2n6s200_joint_2
@@ -35,9 +35,9 @@ jaco_arm_cartesian_controller:
         - j2n6s200_joint_6
       command_interfaces:
         - velocity
-      solver:
-        damped_least_squares:
-          alpha: 0.001
+      # solver:
+      #   damped_least_squares:
+      #     alpha: 0.001
       wrench_threshold:
         topic: /wireless_ft/ftSensor3
         fMag: 1.0


### PR DESCRIPTION
# Description

Our cartesian controller currently uses the [damped least squares solver](https://ieeexplore.ieee.org/abstract/document/4075580). It works well, but has unexpected and scary motion (that often speeds up) near singularities. The motion near singularities also often deviates along unintuitive dimension of the end effector pose (as in, visually I feel the goal could have been better-achieved by deviating along a different dimension). Further, tuning `alpha` is unintuitive imho. 

Instead, this PR shifts our cartesian controller to [selectively damped least squares](https://www.tandfonline.com/doi/abs/10.1080/2151237X.2005.10129202), which adaptively chooses a damping factor, and does so separately for each dimension that has reached singularity. As a result, it promises to have better performance at singularities.

Note that both solvers are implemented in [here](https://github.com/personalrobotics/cartesian_controllers/blob/egordon/twist/cartesian_controller_base/ik_solver_plugin.xml) (the header files for each implementation link to the above papers).

# Testing

- [x] Test cartesian teleop on the web app. Not only did this work very well, I was able to do large motions, like from staging to above plate, which I previously hadn't been able to do with any of the teleop approaches we used. I felt quite safe around it.
- [x] Test acquisition: Acquire 3 bites of food in varied locations relative to the robot, verify it succeeds.
- [x] Test motion to/from mouth. Transfer the bite with the face up against the headrest. Then separately transfer it with the mouth up, down, left, right, and forward relative to that position. (6 transfers total). Verify it succeeds and feels safe. 