### PR TITLE
Add pre-commit routines for prettier formatting on Xacro, launch and package XML files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,3 +67,10 @@ repos:
       - id: codespell
         args:
           - --ignore-words=.codespell-ignore
+
+  - repo: https://github.com/jjaime2/pre-commit-hooks-ros
+    rev: v1.0.0
+    hooks:
+      - id: prettier-xacro
+      - id: prettier-launch-xml
+      - id: prettier-package-xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,7 +68,7 @@ repos:
         args:
           - --ignore-words=.codespell-ignore
 
-  - repo: https://github.com/jjaime2/pre-commit-hooks-ros
+  - repo: https://github.com/personalrobotics/pr-pre-commit-hooks
     rev: v1.0.0
     hooks:
       - id: prettier-xacro

--- a/ada_calibrate_camera/launch/publish_camera_extrinsics_launch.xml
+++ b/ada_calibrate_camera/launch/publish_camera_extrinsics_launch.xml
@@ -2,12 +2,17 @@
    Copyright (c) 2024-2025, Personal Robotics Laboratory
    License: BSD 3-Clause. See LICENSE.md file in root directory.
 -->
-
 <launch>
-  <arg name="calibration_file_name" default="auto" description="Name of the calibration file to save" />
-  <arg name="log_level" default="info" description="Log level to pass to create_action_servers: debug, info, warn" />
+  <arg name="calibration_file_name" default="auto" description="Name of the calibration file to save"/>
+  <arg name="log_level" default="info" description="Log level to pass to create_action_servers: debug, info, warn"/>
 
-  <node pkg="ada_calibrate_camera" exec="publish_camera_extrinsics" name="publish_camera_extrinsics" respawn="true" args="--ros-args --log-level $(var log_level) --log-level rcl:=INFO --log-level rmw_cyclonedds_cpp:=INFO">
+  <node
+    pkg="ada_calibrate_camera"
+    exec="publish_camera_extrinsics"
+    name="publish_camera_extrinsics"
+    respawn="true"
+    args="--ros-args --log-level $(var log_level) --log-level rcl:=INFO --log-level rmw_cyclonedds_cpp:=INFO"
+  >
     <param from="$(find-pkg-share ada_calibrate_camera)/config/calibs/$(var calibration_file_name).yaml"/>
   </node>
 </launch>

--- a/ada_description/package.xml
+++ b/ada_description/package.xml
@@ -3,9 +3,7 @@
 <package format="3">
   <name>ada_description</name>
   <version>0.0.2</version>
-  <description>
-    URDF description for Assistive Dexterous Arm
-  </description>
+  <description>URDF description for Assistive Dexterous Arm</description>
 
   <author>Ethan K. Gordon</author>
 

--- a/ada_description/urdf/ada.xacro
+++ b/ada_description/urdf/ada.xacro
@@ -1,51 +1,82 @@
 <?xml version="1.0"?>
-
-<robot xmlns:xi="http://www.w3.org/2001/XInclude"
+<robot
+  xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
-    xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
+  xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
   xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
   xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
-    xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
-    xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
+  xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
+  xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
   xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
   xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
   xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
-    xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
-    xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-  xmlns:xacro="http://www.ros.org/wiki/xacro" name="ada">
-
+  xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
+  xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
+  xmlns:xacro="http://www.ros.org/wiki/xacro"
+  name="ada"
+>
   <xacro:include filename="$(find ada_description)/urdf/forque/forque.xacro"/>
   <xacro:include filename="$(find ada_description)/urdf/camera/camera.xacro"/>
   <xacro:include filename="$(find ada_description)/urdf/j2n6s200.xacro"/>
 
-  <xacro:arg name="use_forque" default="true"/>
+  <xacro:arg
+    name="use_forque"
+    default="true"
+  />
 
   <link name="root"/>
 
   <link name="root_tilt"/>
-  <joint name="robot_tilt" type="revolute">
-    <origin xyz="0 0 0" rpy="0 0 0" />
-    <child link="root_tilt" />
-    <parent link="root" />
+  <joint
+    name="robot_tilt"
+    type="revolute"
+  >
+    <origin
+      xyz="0 0 0"
+      rpy="0 0 0"
+    />
+    <child link="root_tilt"/>
+    <parent link="root"/>
     <axis xyz="-1 0 0"/>
     <!-- effort copied from j2n6s200 joint 2, velocity is max velocity the wheelchair can tilt,
     lower and upper limits generously encompass the range of the wheelchair's tilt-->
-    <limit effort="80" velocity="0.15" lower="${-J_PI}" upper="${J_PI}"/>
-    <dynamics damping="0.0" friction="0.0"/>
+    <limit
+      effort="80"
+      velocity="0.15"
+      lower="${-J_PI}"
+      upper="${J_PI}"
+    />
+    <dynamics
+      damping="0.0"
+      friction="0.0"
+    />
   </joint>
 
-  <xacro:property name="robot_root" value="root_tilt" />
+  <xacro:property
+    name="robot_root"
+    value="root_tilt"
+  />
 
   <xacro:j2n6s200 base_parent="${robot_root}"/>
 
-  <xacro:camera_assembly base_parent="j2n6s200_link_6" base_xyz="0.0165 0 0.0011" base_rpy="${3*J_PI/2} 0 ${3*J_PI/2}"/>
+  <xacro:camera_assembly
+    base_parent="j2n6s200_link_6"
+    base_xyz="0.0165 0 0.0011"
+    base_rpy="${3*J_PI/2} 0 ${3*J_PI/2}"
+  />
 
   <!-- Hard-coded Extrinsics -->
-  <link name="camera_link" />
-  <joint name="extrinsics" type="fixed">
-    <origin xyz="0.0194 -0.01606 0.029014" rpy="0.17234 -1.56127 2.96967" />
-    <parent link="cameraMount" />
-    <child link="camera_link" />
+  <link name="camera_link"/>
+  <joint
+    name="extrinsics"
+    type="fixed"
+  >
+    <origin
+      xyz="0.0194 -0.01606 0.029014"
+      rpy="0.17234 -1.56127 2.96967"
+    />
+    <parent link="cameraMount"/>
+    <child link="camera_link"/>
   </joint>
   <!-- Copy Realsense in case of simulation -->
   <!--
@@ -57,20 +88,43 @@
   </joint>
   -->
 
-  <xacro:forque_assembly_link link_name="FTArmMount" link_mesh="2024_01_18_FTArmMount" mass="0.03783" cog="0.010957 -0.019223 -0.03777">
-    <inertia ixx="0.000018817" iyy="0.00001119989" iyz="-0.00000120296" izz="0.000026883" ixy="-0.0000003327" ixz="-0.000000092476"/>
+  <xacro:forque_assembly_link
+    link_name="FTArmMount"
+    link_mesh="2024_01_18_FTArmMount"
+    mass="0.03783"
+    cog="0.010957 -0.019223 -0.03777"
+  >
+    <inertia
+      ixx="0.000018817"
+      iyy="0.00001119989"
+      iyz="-0.00000120296"
+      izz="0.000026883"
+      ixy="-0.0000003327"
+      ixz="-0.000000092476"
+    />
   </xacro:forque_assembly_link>
-  <xacro:forque_assembly_joint joint_name="FTArmMount_to_arm" parent="j2n6s200_link_6" child="FTArmMount" joint_origin_xyz="0.0065 -0.011 -0.0075" joint_origin_rpy="${J_PI/2} 0 ${J_PI/2}"/>
+  <xacro:forque_assembly_joint
+    joint_name="FTArmMount_to_arm"
+    parent="j2n6s200_link_6"
+    child="FTArmMount"
+    joint_origin_xyz="0.0065 -0.011 -0.0075"
+    joint_origin_rpy="${J_PI/2} 0 ${J_PI/2}"
+  />
 
   <xacro:if value="$(arg use_forque)">
     <xacro:forque_assembly base_parent="FTArmMount"/>
 
-    <link name="FTSensor" />
-    <joint name="EE_to_FTSensor" type="fixed">
-        <child link="FTSensor"/>
-        <parent link="j2n6s200_end_effector"/>
-        <origin rpy="0 0 0" xyz="0.0 0.0 0.092"/>
+    <link name="FTSensor"/>
+    <joint
+      name="EE_to_FTSensor"
+      type="fixed"
+    >
+      <child link="FTSensor"/>
+      <parent link="j2n6s200_end_effector"/>
+      <origin
+        rpy="0 0 0"
+        xyz="0.0 0.0 0.092"
+      />
     </joint>
   </xacro:if>
-
 </robot>

--- a/ada_description/urdf/camera/camera.xacro
+++ b/ada_description/urdf/camera/camera.xacro
@@ -1,117 +1,296 @@
 <?xml version="1.0"?>
+<root
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
+  xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
+  xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+  xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
+  xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
+  xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
+  xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+  xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+  xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
+  xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
+  xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
+  xmlns:xacro="http://www.ros.org/wiki/xacro"
+>
+  <xacro:include filename="$(find ada_description)/urdf/camera/d415urdf.xacro"/>
 
-<root xmlns:xi="http://www.w3.org/2001/XInclude"
-	xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
-    xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
-	xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-	xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
-    xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
-    xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
-	xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-	xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
-	xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
-    xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
-    xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-	xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:property
+    name="camColor"
+    value="0.4 0.4 0.4 1"
+  />
+  <xacro:property
+    name="J_PI"
+    value="3.1415926535897931"
+  />
 
-	<xacro:include filename="$(find ada_description)/urdf/camera/d415urdf.xacro"/>
+  <xacro:property name="default_inertial">
+    <inertia
+      ixx="0.000005"
+      iyy="0.000005"
+      iyz="0"
+      izz="0.000005"
+      ixy="0"
+      ixz="0"
+    />
+  </xacro:property>
 
-	<xacro:property name="camColor" value="0.4 0.4 0.4 1" />
-	<xacro:property name="J_PI" value="3.1415926535897931" />
+  <xacro:macro
+    name="camera_assembly_link"
+    params="link_name link_mesh mass:=0 cog:='0 0 0' *inertia"
+  >
+    <link name="${link_name}">
+      <visual>
+        <geometry>
+          <mesh
+            filename="package://ada_description/meshes/camera/${link_mesh}.stl"
+            scale="0.001 0.001 0.001"
+          />
+        </geometry>
+        <material name="abs">
+          <color rgba="${camColor}"/>
+        </material>
+      </visual>
+      <collision>
+        <geometry>
+          <mesh
+            filename="package://ada_description/meshes/camera/${link_mesh}.stl"
+            scale="0.001 0.001 0.001"
+          />
+        </geometry>
+      </collision>
+      <inertial>
+        <origin
+          xyz="${cog}"
+          rpy="0 0 0"
+        />
+        <mass value="${mass}"/>
+        <xacro:insert_block name="inertia"/>
+      </inertial>
+    </link>
+  </xacro:macro>
 
-	<xacro:property name="default_inertial">
-		<inertia ixx="0.000005" iyy="0.000005" iyz="0" izz="0.000005" ixy="0" ixz="0"/>
-	</xacro:property>
+  <xacro:macro
+    name="camera_assembly_joint"
+    params="joint_name parent child joint_origin_xyz joint_origin_rpy"
+  >
+    <joint
+      name="${joint_name}"
+      type="fixed"
+    >
+      <parent link="${parent}"/>
+      <child link="${child}"/>
+      <axis xyz="0 0 1"/>
+      <origin
+        xyz="${joint_origin_xyz}"
+        rpy="${joint_origin_rpy}"
+      />
+    </joint>
+  </xacro:macro>
 
+  <xacro:property
+    name="default_origin"
+    value="0 0 0"
+  />
 
-	<xacro:macro name="camera_assembly_link" params="link_name link_mesh mass:=0 cog:='0 0 0' *inertia">
-		<link name="${link_name}">
-			<visual>
-				<geometry>
-					<mesh
-						filename="package://ada_description/meshes/camera/${link_mesh}.stl"
-						scale="0.001 0.001 0.001"/>
-				</geometry>
-				<material name="abs">
-					<color rgba="${camColor}" />
-				</material>
-			</visual>
-			<collision>
-                <geometry>
-                    <mesh
-						filename="package://ada_description/meshes/camera/${link_mesh}.stl"
-						scale="0.001 0.001 0.001"/>
-                </geometry>
-            </collision>
-            <inertial>
-            	<origin xyz="${cog}" rpy="0 0 0"/>
-            	<mass value="${mass}"/>
-            	<xacro:insert_block name="inertia"/>
-            </inertial>
-		</link>
-	</xacro:macro>
+  <xacro:macro
+    name="camera_assembly"
+    params="base_parent base_xyz:=${default_origin} base_rpy:=${default_origin}"
+  >
+    <xacro:camera_assembly_link
+      link_name="nanoMount"
+      link_mesh="2023_03_09_nanoArmMount"
+      mass="0.008"
+      cog="-0.002400 0.0046958 0.0115245"
+    >
+      <inertia
+        ixx="0.00000095025"
+        iyy="0.0000067325"
+        iyz="0.000000000470196"
+        izz="0.0000069433"
+        ixy="-0.000000297842"
+        ixz="-0.00000000010444"
+      />
+    </xacro:camera_assembly_link>
+    <xacro:camera_assembly_joint
+      joint_name="nanoMount_to_world"
+      parent="${base_parent}"
+      child="nanoMount"
+      joint_origin_xyz="${base_xyz}"
+      joint_origin_rpy="${base_rpy}"
+    />
 
-	<xacro:macro name="camera_assembly_joint" params="joint_name parent child joint_origin_xyz joint_origin_rpy">
-		<joint name="${joint_name}" type="fixed">
-			<parent link="${parent}"/>
-			<child link="${child}"/>
-			<axis xyz="0 0 1"/>
-			<origin xyz="${joint_origin_xyz}" rpy="${joint_origin_rpy}"/>
-		</joint>
-	</xacro:macro>
+    <xacro:camera_assembly_link
+      link_name="enclosureBottom"
+      link_mesh="2023_09_28_nanoEnclosureBottom"
+      mass="0.040"
+      cog="0.0546451 0.0472161 0.00043655"
+    >
+      <inertia
+        ixx="0.000041028"
+        iyy="0.000083168"
+        iyz="0.0000026243"
+        izz="0.000116424"
+        ixy="-0.000000324"
+        ixz="-0.00000045367"
+      />
+    </xacro:camera_assembly_link>
+    <xacro:camera_assembly_joint
+      joint_name="enclosureBottom_to_nanoMount"
+      parent="nanoMount"
+      child="enclosureBottom"
+      joint_origin_xyz="0.0412 -0.0218 0.026"
+      joint_origin_rpy="0 0 ${J_PI/2}"
+    />
 
+    <xacro:camera_assembly_link
+      link_name="nano"
+      link_mesh="2023_03_21_jetsonNano"
+      mass="0.142"
+      cog="0.0435615 0.02502709 0.0091247"
+    >
+      <inertia
+        ixx="0.000077456"
+        iyy="0.0001013"
+        iyz="0.0000036951"
+        izz="0.0001727"
+        ixy="-0.000004935"
+        ixz="0.0000015461"
+      />
+    </xacro:camera_assembly_link>
+    <xacro:camera_assembly_joint
+      joint_name="nano_to_enclosureBottom"
+      parent="enclosureBottom"
+      child="nano"
+      joint_origin_xyz="0.0105 0.014 -0.0015"
+      joint_origin_rpy="0 0 0"
+    />
 
+    <xacro:camera_assembly_link
+      link_name="frontStabilizer"
+      link_mesh="2023_09_21_nanoEnclosureFrontStabilizer"
+      mass="0.0198"
+      cog="-0.008107 -0.000955 0.02045"
+    >
+      <inertia
+        ixx="0.00000074776"
+        iyy="0.0000118843"
+        iyz="0.00000001021778"
+        izz="0.0000119096"
+        ixy="0.000000000071856"
+        ixz="0.0000000002764"
+      />
+    </xacro:camera_assembly_link>
+    <xacro:camera_assembly_joint
+      joint_name="frontStabilizer_to_enclosureBottom"
+      parent="enclosureBottom"
+      child="frontStabilizer"
+      joint_origin_xyz="0.1063 0.0493 -0.0363"
+      joint_origin_rpy="0 0 ${J_PI/2}"
+    />
 
-	<xacro:property name="default_origin" value="0 0 0"/>
+    <xacro:camera_assembly_link
+      link_name="enclosureTop"
+      link_mesh="2023_06_06_nanoEnclosureTopCameraBack"
+      mass="0.046"
+      cog="0.041228 0.006275 0.016379"
+    >
+      <inertia
+        ixx="0.00005942"
+        iyy="0.000085611"
+        iyz="0.0000012783"
+        izz="0.000126390"
+        ixy="-0.000000046193"
+        ixz="0.0000091699"
+      />
+    </xacro:camera_assembly_link>
+    <xacro:camera_assembly_joint
+      joint_name="enclosureTop_to_enclosureBottom"
+      parent="enclosureBottom"
+      child="enclosureTop"
+      joint_origin_xyz="0.009925 0.04099 0.05442"
+      joint_origin_rpy="0 ${165.4 * J_PI / 180} ${J_PI}"
+    />
 
-	<xacro:macro name="camera_assembly" params="base_parent base_xyz:=${default_origin} base_rpy:=${default_origin}">
+    <xacro:camera_assembly_link
+      link_name="cameraMount"
+      link_mesh="2023_06_06_cameraBackMount"
+      mass="0.004"
+      cog="-0.007986 0 0.010064"
+    >
+      <inertia
+        ixx="0.000002782"
+        iyy="00.0000005528"
+        iyz="-0.00000000000178"
+        izz="0.000002964"
+        ixy="-0.00000000002321"
+        ixz="0.000000074385"
+      />
+    </xacro:camera_assembly_link>
+    <xacro:camera_assembly_joint
+      joint_name="cameraMount_to_enclosureTop"
+      parent="enclosureTop"
+      child="cameraMount"
+      joint_origin_xyz="-0.0132 0 -0.022"
+      joint_origin_rpy="0 ${J_PI / 2} 0"
+    />
 
-		<xacro:camera_assembly_link link_name="nanoMount" link_mesh="2023_03_09_nanoArmMount" mass="0.008" cog="-0.002400 0.0046958 0.0115245">
-			<inertia ixx="0.00000095025" iyy="0.0000067325" iyz="0.000000000470196" izz="0.0000069433" ixy="-0.000000297842" ixz="-0.00000000010444"/>
-        </xacro:camera_assembly_link>
-	  	<xacro:camera_assembly_joint joint_name="nanoMount_to_world" parent="${base_parent}" child="nanoMount" joint_origin_xyz="${base_xyz}" joint_origin_rpy="${base_rpy}"/>
+    <xacro:camera_assembly_link
+      link_name="screwHeadLeft"
+      link_mesh="2023_11_07_screwHead"
+      mass="0.0001"
+      cog="0 0 0.0015"
+    >
+      <inertia
+        ixx="0.000000000342785"
+        iyy="0.000000000342785"
+        iyz="0"
+        izz="0.000000000543538"
+        ixy="0"
+        ixz="0"
+      />
+    </xacro:camera_assembly_link>
+    <xacro:camera_assembly_joint
+      joint_name="screwHeadLeft_to_cameraMount"
+      parent="cameraMount"
+      child="screwHeadLeft"
+      joint_origin_xyz="0.0165 -0.0225 0"
+      joint_origin_rpy="${J_PI} 0 0"
+    />
 
-		<xacro:camera_assembly_link link_name="enclosureBottom" link_mesh="2023_09_28_nanoEnclosureBottom" mass="0.040" cog="0.0546451 0.0472161 0.00043655">
-	  		<inertia ixx="0.000041028" iyy="0.000083168" iyz="0.0000026243" izz="0.000116424" ixy="-0.000000324" ixz="-0.00000045367"/>
-	  	</xacro:camera_assembly_link>
-		<xacro:camera_assembly_joint joint_name="enclosureBottom_to_nanoMount" parent="nanoMount" child="enclosureBottom" joint_origin_xyz="0.0412 -0.0218 0.026" joint_origin_rpy="0 0 ${J_PI/2}"/>
+    <xacro:camera_assembly_link
+      link_name="screwHeadRight"
+      link_mesh="2023_11_07_screwHead"
+      mass="0.0001"
+      cog="0 0 0.0015"
+    >
+      <inertia
+        ixx="0.000000000342785"
+        iyy="0.000000000342785"
+        iyz="0"
+        izz="0.000000000543538"
+        ixy="0"
+        ixz="0"
+      />
+    </xacro:camera_assembly_link>
+    <xacro:camera_assembly_joint
+      joint_name="screwHeadRight_to_cameraMount"
+      parent="cameraMount"
+      child="screwHeadRight"
+      joint_origin_xyz="0.0165 0.0225 0"
+      joint_origin_rpy="${J_PI} 0 0"
+    />
 
-		<xacro:camera_assembly_link link_name="nano" link_mesh="2023_03_21_jetsonNano" mass="0.142" cog="0.0435615 0.02502709 0.0091247">
-	  		<inertia ixx="0.000077456" iyy="0.0001013" iyz="0.0000036951" izz="0.0001727" ixy="-0.000004935" ixz="0.0000015461"/>
-	  	</xacro:camera_assembly_link>
-		<xacro:camera_assembly_joint joint_name="nano_to_enclosureBottom" parent="enclosureBottom" child="nano" joint_origin_xyz="0.0105 0.014 -0.0015" joint_origin_rpy="0 0 0"/>
-
-		<xacro:camera_assembly_link link_name="frontStabilizer" link_mesh="2023_09_21_nanoEnclosureFrontStabilizer" mass="0.0198" cog="-0.008107 -0.000955 0.02045">
-	  		<inertia ixx="0.00000074776" iyy="0.0000118843" iyz="0.00000001021778" izz="0.0000119096" ixy="0.000000000071856" ixz="0.0000000002764"/>
-	  	</xacro:camera_assembly_link>
-		<xacro:camera_assembly_joint joint_name="frontStabilizer_to_enclosureBottom" parent="enclosureBottom" child="frontStabilizer" joint_origin_xyz="0.1063 0.0493 -0.0363" joint_origin_rpy="0 0 ${J_PI/2}"/>
-
-		<xacro:camera_assembly_link link_name="enclosureTop" link_mesh="2023_06_06_nanoEnclosureTopCameraBack" mass="0.046" cog="0.041228 0.006275 0.016379">
-	  		<inertia ixx="0.00005942" iyy="0.000085611" iyz="0.0000012783" izz="0.000126390" ixy="-0.000000046193" ixz="0.0000091699"/>
-	  	</xacro:camera_assembly_link>
-		<xacro:camera_assembly_joint joint_name="enclosureTop_to_enclosureBottom" parent="enclosureBottom" child="enclosureTop" joint_origin_xyz="0.009925 0.04099 0.05442" joint_origin_rpy="0 ${165.4 * J_PI / 180} ${J_PI}"/>
-
-		<xacro:camera_assembly_link link_name="cameraMount" link_mesh="2023_06_06_cameraBackMount" mass="0.004" cog="-0.007986 0 0.010064">
-	  		<inertia ixx="0.000002782" iyy="00.0000005528" iyz="-0.00000000000178" izz="0.000002964" ixy="-0.00000000002321" ixz="0.000000074385"/>
-	  	</xacro:camera_assembly_link>
-		<xacro:camera_assembly_joint joint_name="cameraMount_to_enclosureTop" parent="enclosureTop" child="cameraMount" joint_origin_xyz="-0.0132 0 -0.022" joint_origin_rpy="0 ${J_PI / 2} 0"/>
-
-		<xacro:camera_assembly_link link_name="screwHeadLeft" link_mesh="2023_11_07_screwHead" mass="0.0001" cog="0 0 0.0015">
-     		<inertia ixx="0.000000000342785" iyy="0.000000000342785" iyz="0" izz="0.000000000543538" ixy="0" ixz="0"/>
-     	</xacro:camera_assembly_link>
-   	 	<xacro:camera_assembly_joint joint_name="screwHeadLeft_to_cameraMount" parent="cameraMount" child="screwHeadLeft" joint_origin_xyz="0.0165 -0.0225 0" joint_origin_rpy="${J_PI} 0 0"/>
-
-   	 	<xacro:camera_assembly_link link_name="screwHeadRight" link_mesh="2023_11_07_screwHead" mass="0.0001" cog="0 0 0.0015">
-     		<inertia ixx="0.000000000342785" iyy="0.000000000342785" iyz="0" izz="0.000000000543538" ixy="0" ixz="0"/>
-     	</xacro:camera_assembly_link>
-   	 	<xacro:camera_assembly_joint joint_name="screwHeadRight_to_cameraMount" parent="cameraMount" child="screwHeadRight" joint_origin_xyz="0.0165 0.0225 0" joint_origin_rpy="${J_PI} 0 0"/>
-
-   	 	<xacro:sensor_d415 parent="cameraMount" use_mesh="true" name="uncalibrated_camera">
-   		 	<origin xyz="0.006 0 0.013" rpy="0 ${-J_PI / 2} ${J_PI}" />
-   	 	</xacro:sensor_d415>
-
-
-	</xacro:macro>
-
-
+    <xacro:sensor_d415
+      parent="cameraMount"
+      use_mesh="true"
+      name="uncalibrated_camera"
+    >
+      <origin
+        xyz="0.006 0 0.013"
+        rpy="0 ${-J_PI / 2} ${J_PI}"
+      />
+    </xacro:sensor_d415>
+  </xacro:macro>
 </root>

--- a/ada_description/urdf/camera/camera_standalone.xacro
+++ b/ada_description/urdf/camera/camera_standalone.xacro
@@ -1,35 +1,43 @@
 <?xml version="1.0"?>
-
-<robot xmlns:xi="http://www.w3.org/2001/XInclude"
+<robot
+  xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
-    xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
+  xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
   xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
   xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
-    xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
-    xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
+  xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
+  xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
   xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
   xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
   xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
-    xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
-    xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-  xmlns:xacro="http://www.ros.org/wiki/xacro" name="camera">
-
- <xacro:include filename="$(find ada_description)/urdf/camera/camera.xacro"/>
+  xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
+  xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
+  xmlns:xacro="http://www.ros.org/wiki/xacro"
+  name="camera"
+>
+  <xacro:include filename="$(find ada_description)/urdf/camera/camera.xacro"/>
 
   <link name="root"/>
 
   <!-- for gazebo -->
   <link name="world"/>
 
-  <joint name="connect_root_and_world" type="fixed">
-    <child link="root" />
-    <parent link="world" />
-    <origin xyz="0 0 0" rpy="0 0 0" />
+  <joint
+    name="connect_root_and_world"
+    type="fixed"
+  >
+    <child link="root"/>
+    <parent link="world"/>
+    <origin
+      xyz="0 0 0"
+      rpy="0 0 0"
+    />
   </joint>
 
-  <xacro:property name="robot_root" value="root" />
+  <xacro:property
+    name="robot_root"
+    value="root"
+  />
 
   <xacro:camera_assembly base_parent="${robot_root}"/>
-
-
 </robot>

--- a/ada_description/urdf/camera/d415urdf.xacro
+++ b/ada_description/urdf/camera/d415urdf.xacro
@@ -14,14 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -->
-
 <!--
 This is the URDF model for the Intel RealSense 415 camera, in its
 aluminum peripheral evaluation case.
 -->
-
-<robot name="sensor_d415" xmlns:xacro="http://ros.org/wiki/xacro">
-
+<robot
+  name="sensor_d415"
+  xmlns:xacro="http://ros.org/wiki/xacro"
+>
   <material name="aluminum">
     <color rgba="0.4 0.4 0.4 1"/>
   </material>
@@ -29,140 +29,255 @@ aluminum peripheral evaluation case.
     <color rgba="0.1 0.1 0.1 1"/>
   </material>
 
-
-  <xacro:macro name="sensor_d415" params="parent *origin  name:=camera  use_nominal_extrinsics:=false add_plug:=false use_mesh:=true">
-    <xacro:property name="M_PI" value="3.1415926535897931" />
+  <xacro:macro
+    name="sensor_d415"
+    params="parent *origin  name:=camera  use_nominal_extrinsics:=false add_plug:=false use_mesh:=true"
+  >
+    <xacro:property
+      name="M_PI"
+      value="3.1415926535897931"
+    />
 
     <!-- The following values are approximate, and the camera node
      publishing TF values with actual calibrated camera extrinsic values -->
-    <xacro:property name="d415_cam_depth_to_infra1_offset" value="0.0"/>
-    <xacro:property name="d415_cam_depth_to_infra2_offset" value="-0.055"/>
-    <xacro:property name="d415_cam_depth_to_color_offset" value="0.015"/>
+    <xacro:property
+      name="d415_cam_depth_to_infra1_offset"
+      value="0.0"
+    />
+    <xacro:property
+      name="d415_cam_depth_to_infra2_offset"
+      value="-0.055"
+    />
+    <xacro:property
+      name="d415_cam_depth_to_color_offset"
+      value="0.015"
+    />
 
     <!-- The following values model the aluminum peripheral case for the
   	d415 camera, with the camera joint represented by the actual
   	peripheral camera tripod mount -->
-    <xacro:property name="d415_cam_width" value="0.099"/>
-    <xacro:property name="d415_cam_height" value="0.023"/>
-    <xacro:property name="d415_cam_depth" value="0.02005"/>
-    <xacro:property name="d415_cam_mount_from_center_offset" value="0.00987"/>
+    <xacro:property
+      name="d415_cam_width"
+      value="0.099"
+    />
+    <xacro:property
+      name="d415_cam_height"
+      value="0.023"
+    />
+    <xacro:property
+      name="d415_cam_depth"
+      value="0.02005"
+    />
+    <xacro:property
+      name="d415_cam_mount_from_center_offset"
+      value="0.00987"
+    />
 
     <!-- The following offset is relative the the physical d415 camera peripheral
   	camera tripod mount -->
-    <xacro:property name="d415_cam_depth_px" value="${d415_cam_mount_from_center_offset}"/>
-    <xacro:property name="d415_cam_depth_py" value="0.020"/>
-    <xacro:property name="d415_cam_depth_pz" value="${d415_cam_height/2}"/>
+    <xacro:property
+      name="d415_cam_depth_px"
+      value="${d415_cam_mount_from_center_offset}"
+    />
+    <xacro:property
+      name="d415_cam_depth_py"
+      value="0.020"
+    />
+    <xacro:property
+      name="d415_cam_depth_pz"
+      value="${d415_cam_height/2}"
+    />
 
     <!-- camera body, with origin at bottom screw mount -->
-    <joint name="${name}_joint" type="fixed">
-      <xacro:insert_block name="origin" />
+    <joint
+      name="${name}_joint"
+      type="fixed"
+    >
+      <xacro:insert_block name="origin"/>
       <parent link="${parent}"/>
-      <child link="${name}_bottom_screw_frame" />
+      <child link="${name}_bottom_screw_frame"/>
     </joint>
 
     <link name="${name}_bottom_screw_frame"/>
 
-    <joint name="${name}_link_joint" type="fixed">
-      <origin xyz="0 ${d415_cam_depth_py} ${d415_cam_depth_pz}" rpy="0 0 0"/>
+    <joint
+      name="${name}_link_joint"
+      type="fixed"
+    >
+      <origin
+        xyz="0 ${d415_cam_depth_py} ${d415_cam_depth_pz}"
+        rpy="0 0 0"
+      />
       <parent link="${name}_bottom_screw_frame"/>
-      <child link="${name}_link" />
+      <child link="${name}_link"/>
     </joint>
 
     <link name="${name}_link">
       <visual>
         <xacro:if value="${use_mesh}">
-          <origin xyz="${d415_cam_mount_from_center_offset} ${-d415_cam_depth_py} 0" rpy="${M_PI/2} 0 ${M_PI/2}"/>
+          <origin
+            xyz="${d415_cam_mount_from_center_offset} ${-d415_cam_depth_py} 0"
+            rpy="${M_PI/2} 0 ${M_PI/2}"
+          />
           <geometry>
-            <mesh filename="package://ada_description/meshes/camera/d415.stl" />
+            <mesh filename="package://ada_description/meshes/camera/d415.stl"/>
           </geometry>
           <material name="aluminum"/>
         </xacro:if>
         <xacro:unless value="${use_mesh}">
-          <origin xyz="0 ${-d415_cam_depth_py} 0" rpy="0 0 0"/>
+          <origin
+            xyz="0 ${-d415_cam_depth_py} 0"
+            rpy="0 0 0"
+          />
           <geometry>
             <box size="${d415_cam_depth} ${d415_cam_width} ${d415_cam_height}"/>
           </geometry>
         </xacro:unless>
       </visual>
       <collision>
-        <origin xyz="0 ${-d415_cam_depth_py} 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 ${-d415_cam_depth_py} 0"
+          rpy="0 0 0"
+        />
         <geometry>
-        <box size="${d415_cam_depth} ${d415_cam_width} ${d415_cam_height}"/>
+          <box size="${d415_cam_depth} ${d415_cam_width} ${d415_cam_height}"/>
         </geometry>
       </collision>
       <inertial>
-        <mass value="0.0589" /> <!-- manufacturer's value: 0.072 -->
-        <origin xyz="0 -0.02 0" />
-        <inertia ixx="0.00005491" ixy="-0.0000000249492" ixz="0.00000004862028" iyy="0.00000521068" iyz="0.00000000857625" izz="0.0000554597" />
+        <mass value="0.0589"/>
+        <!-- manufacturer's value: 0.072 -->
+        <origin xyz="0 -0.02 0"/>
+        <inertia
+          ixx="0.00005491"
+          ixy="-0.0000000249492"
+          ixz="0.00000004862028"
+          iyy="0.00000521068"
+          iyz="0.00000000857625"
+          izz="0.0000554597"
+        />
       </inertial>
     </link>
 
     <!-- Use the nominal extrinsics between camera frames if the calibrated extrinsics aren't being published. e.g. running the device in simulation  -->
     <xacro:if value="${use_nominal_extrinsics}">
       <!-- camera depth joints and links -->
-      <joint name="${name}_depth_joint" type="fixed">
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+      <joint
+        name="${name}_depth_joint"
+        type="fixed"
+      >
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0"
+        />
         <parent link="${name}_link"/>
-        <child link="${name}_depth_frame" />
+        <child link="${name}_depth_frame"/>
       </joint>
       <link name="${name}_depth_frame"/>
 
-      <joint name="${name}_depth_optical_joint" type="fixed">
-        <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-        <parent link="${name}_depth_frame" />
-        <child link="${name}_depth_optical_frame" />
+      <joint
+        name="${name}_depth_optical_joint"
+        type="fixed"
+      >
+        <origin
+          xyz="0 0 0"
+          rpy="${-M_PI/2} 0 ${-M_PI/2}"
+        />
+        <parent link="${name}_depth_frame"/>
+        <child link="${name}_depth_optical_frame"/>
       </joint>
       <link name="${name}_depth_optical_frame"/>
 
       <!-- camera left IR joints and links -->
-      <joint name="${name}_infra1_joint" type="fixed">
-        <origin xyz="0 ${d415_cam_depth_to_infra1_offset} 0" rpy="0 0 0" />
-        <parent link="${name}_link" />
-        <child link="${name}_infra1_frame" />
+      <joint
+        name="${name}_infra1_joint"
+        type="fixed"
+      >
+        <origin
+          xyz="0 ${d415_cam_depth_to_infra1_offset} 0"
+          rpy="0 0 0"
+        />
+        <parent link="${name}_link"/>
+        <child link="${name}_infra1_frame"/>
       </joint>
       <link name="${name}_infra1_frame"/>
 
-      <joint name="${name}_infra1_optical_joint" type="fixed">
-        <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-        <parent link="${name}_infra1_frame" />
-        <child link="${name}_infra1_optical_frame" />
+      <joint
+        name="${name}_infra1_optical_joint"
+        type="fixed"
+      >
+        <origin
+          xyz="0 0 0"
+          rpy="${-M_PI/2} 0 ${-M_PI/2}"
+        />
+        <parent link="${name}_infra1_frame"/>
+        <child link="${name}_infra1_optical_frame"/>
       </joint>
       <link name="${name}_infra1_optical_frame"/>
 
       <!-- camera right IR joints and links -->
-      <joint name="${name}_infra2_joint" type="fixed">
-        <origin xyz="0 ${d415_cam_depth_to_infra2_offset} 0" rpy="0 0 0" />
-        <parent link="${name}_link" />
-        <child link="${name}_infra2_frame" />
+      <joint
+        name="${name}_infra2_joint"
+        type="fixed"
+      >
+        <origin
+          xyz="0 ${d415_cam_depth_to_infra2_offset} 0"
+          rpy="0 0 0"
+        />
+        <parent link="${name}_link"/>
+        <child link="${name}_infra2_frame"/>
       </joint>
       <link name="${name}_infra2_frame"/>
 
-      <joint name="${name}_infra2_optical_joint" type="fixed">
-        <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-        <parent link="${name}_infra2_frame" />
-        <child link="${name}_infra2_optical_frame" />
+      <joint
+        name="${name}_infra2_optical_joint"
+        type="fixed"
+      >
+        <origin
+          xyz="0 0 0"
+          rpy="${-M_PI/2} 0 ${-M_PI/2}"
+        />
+        <parent link="${name}_infra2_frame"/>
+        <child link="${name}_infra2_optical_frame"/>
       </joint>
       <link name="${name}_infra2_optical_frame"/>
 
       <!-- camera color joints and links -->
-      <joint name="${name}_color_joint" type="fixed">
-        <origin xyz="0 ${d415_cam_depth_to_color_offset} 0" rpy="0 0 0" />
-        <parent link="${name}_link" />
-        <child link="${name}_color_frame" />
+      <joint
+        name="${name}_color_joint"
+        type="fixed"
+      >
+        <origin
+          xyz="0 ${d415_cam_depth_to_color_offset} 0"
+          rpy="0 0 0"
+        />
+        <parent link="${name}_link"/>
+        <child link="${name}_color_frame"/>
       </joint>
       <link name="${name}_color_frame"/>
 
-      <joint name="${name}_color_optical_joint" type="fixed">
-        <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-        <parent link="${name}_color_frame" />
-        <child link="${name}_color_optical_frame" />
+      <joint
+        name="${name}_color_optical_joint"
+        type="fixed"
+      >
+        <origin
+          xyz="0 0 0"
+          rpy="${-M_PI/2} 0 ${-M_PI/2}"
+        />
+        <parent link="${name}_color_frame"/>
+        <child link="${name}_color_optical_frame"/>
       </joint>
       <link name="${name}_color_optical_frame"/>
     </xacro:if>
 
     <xacro:if value="${add_plug}">
-      <xacro:usb_plug parent="${name}_link" name="${name}_usb_plug">
-        <origin xyz="${d415_cam_mount_from_center_offset - 0.01587} ${-d415_cam_depth_py - 0.0358} 0" rpy="0 0 0"/>
+      <xacro:usb_plug
+        parent="${name}_link"
+        name="${name}_usb_plug"
+      >
+        <origin
+          xyz="${d415_cam_mount_from_center_offset - 0.01587} ${-d415_cam_depth_py - 0.0358} 0"
+          rpy="0 0 0"
+        />
       </xacro:usb_plug>
     </xacro:if>
   </xacro:macro>

--- a/ada_description/urdf/forque/forque.xacro
+++ b/ada_description/urdf/forque/forque.xacro
@@ -1,113 +1,264 @@
 <?xml version="1.0"?>
+<root
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
+  xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
+  xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+  xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
+  xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
+  xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
+  xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+  xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+  xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
+  xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
+  xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
+  xmlns:xacro="http://www.ros.org/wiki/xacro"
+>
+  <xacro:property
+    name="forque_color"
+    value="0.4 0.4 0.4 1"
+  />
+  <xacro:property
+    name="J_PI"
+    value="3.1415926535897931"
+  />
+  <xacro:property name="default_inertial">
+    <inertia
+      ixx="0.000005"
+      iyy="0.000005"
+      iyz="0"
+      izz="0.000005"
+      ixy="0"
+      ixz="0"
+    />
+  </xacro:property>
 
-<root xmlns:xi="http://www.w3.org/2001/XInclude"
-	xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
-    xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
-	xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-	xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
-    xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
-    xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
-	xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-	xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
-	xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
-    xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
-    xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-	xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:macro
+    name="forque_assembly_link"
+    params="link_name link_mesh mass:=0 cog:='0 0 0' *inertia"
+  >
+    <link name="${link_name}">
+      <visual>
+        <geometry>
+          <mesh
+            filename="package://ada_description/meshes/forque/${link_mesh}.stl"
+            scale="0.001 0.001 0.001"
+          />
+        </geometry>
+        <material name="abs">
+          <color rgba="${forque_color}"/>
+        </material>
+      </visual>
+      <collision>
+        <geometry>
+          <mesh
+            filename="package://ada_description/meshes/forque/${link_mesh}.stl"
+            scale="0.001 0.001 0.001"
+          />
+        </geometry>
+      </collision>
+      <inertial>
+        <origin
+          xyz="${cog}"
+          rpy="0 0 0"
+        />
+        <mass value="${mass}"/>
+        <xacro:insert_block name="inertia"/>
+      </inertial>
+    </link>
+  </xacro:macro>
 
-	<xacro:property name="forque_color" value="0.4 0.4 0.4 1" />
-	<xacro:property name="J_PI" value="3.1415926535897931" />
-	<xacro:property name="default_inertial">
-		<inertia ixx="0.000005" iyy="0.000005" iyz="0" izz="0.000005" ixy="0" ixz="0"/>
-	</xacro:property>
+  <xacro:macro
+    name="forque_assembly_joint"
+    params="joint_name parent child joint_origin_xyz joint_origin_rpy"
+  >
+    <joint
+      name="${joint_name}"
+      type="fixed"
+    >
+      <parent link="${parent}"/>
+      <child link="${child}"/>
+      <axis xyz="0 0 1"/>
+      <origin
+        xyz="${joint_origin_xyz}"
+        rpy="${joint_origin_rpy}"
+      />
+    </joint>
+  </xacro:macro>
 
+  <xacro:macro
+    name="forque_assembly"
+    params="base_parent use_antenna:=false"
+  >
+    <xacro:forque_assembly_link
+      link_name="FTMount"
+      link_mesh="2024_01_18_FTMount"
+      mass="0.103"
+      cog="0.010934 -0.138522 -0.05066"
+    >
+      <inertia
+        ixx="0.00017623"
+        iyy="0.000068428"
+        iyz="-0.00001757133"
+        izz="0.00021455"
+        ixy="0.00000095729"
+        ixz="-0.0000000562908"
+      />
+    </xacro:forque_assembly_link>
+    <xacro:forque_assembly_joint
+      joint_name="FTMount_to_world"
+      parent="${base_parent}"
+      child="FTMount"
+      joint_origin_xyz="0 0 -0.005"
+      joint_origin_rpy="0 0 0"
+    />
 
-	<xacro:macro name="forque_assembly_link" params="link_name link_mesh mass:=0 cog:='0 0 0' *inertia">
-		<link name="${link_name}">
-			<visual>
-				<geometry>
-					<mesh
-						filename="package://ada_description/meshes/forque/${link_mesh}.stl"
-						scale="0.001 0.001 0.001"/>
-				</geometry>
-				<material name="abs">
-					<color rgba="${forque_color}" />
-				</material>
-			</visual>
-			<collision>
-                <geometry>
-                    <mesh
-						filename="package://ada_description/meshes/forque/${link_mesh}.stl"
-						scale="0.001 0.001 0.001"/>
-                </geometry>
-            </collision>
-            <inertial>
-            	<origin xyz="${cog}" rpy="0 0 0"/>
-            	<mass value="${mass}"/>
-            	<xacro:insert_block name="inertia"/>
-            </inertial>
-		</link>
-	</xacro:macro>
+    <xacro:forque_assembly_link
+      link_name="FT"
+      link_mesh="2023_03_09_wirelessFT"
+      mass="0.280"
+      cog="0.0111446 -0.0882070 -0.0544936"
+    >
+      <inertia
+        ixx="0.000543925"
+        iyy="0.000165428"
+        iyz="-0.00000001487288"
+        izz="0.000691232"
+        ixy="-0.00000128367"
+        ixz="0"
+      />
+    </xacro:forque_assembly_link>
+    <xacro:forque_assembly_joint
+      joint_name="FT_to_FTMount"
+      parent="FTMount"
+      child="FT"
+      joint_origin_xyz="0 0 0"
+      joint_origin_rpy="0 0 0"
+    />
 
-	<xacro:macro name="forque_assembly_joint" params="joint_name parent child joint_origin_xyz joint_origin_rpy">
-		<joint name="${joint_name}" type="fixed">
-			<parent link="${parent}"/>
-			<child link="${child}"/>
-			<axis xyz="0 0 1"/>
-			<origin xyz="${joint_origin_xyz}" rpy="${joint_origin_rpy}"/>
-		</joint>
-	</xacro:macro>
+    <xacro:if value="${use_antenna}">
+      <xacro:forque_assembly_link
+        link_name="FTAntenna"
+        link_mesh="2023_03_09_wirelessFTAntenna"
+        mass="0.018"
+        cog="-0.0162965 0.0666626 -0.0545096"
+      >
+        <xacro:insert_block name="default_inertial"/>
+      </xacro:forque_assembly_link>
+      <xacro:forque_assembly_joint
+        joint_name="FTAntenna_to_FT"
+        parent="FT"
+        child="FTAntenna"
+        joint_origin_xyz="0 0 0"
+        joint_origin_rpy="0 0 0"
+      />
+    </xacro:if>
 
+    <xacro:forque_assembly_link
+      link_name="forkHandle"
+      link_mesh="2024_06_24_forkHandleHollow"
+      mass="0.028"
+      cog="0.011097 -0.162629 -0.011948"
+    >
+      <inertia
+        ixx="0.00003114"
+        iyy="0.000011867"
+        iyz="0.00000054005"
+        izz="0.000038478"
+        ixy="-0.00000050626"
+        ixz="0.000000082271"
+      />
+    </xacro:forque_assembly_link>
 
-	<xacro:macro name="forque_assembly" params="base_parent use_antenna:=false">
+    <!-- The slight rotation was manually added due to empirical deformations in the robot gripped, such that the fingers and fork handle were slightly pitched up relative to the wrist. -->
+    <xacro:forque_assembly_joint
+      joint_name="forkHandle_to_FTMount"
+      parent="FTMount"
+      child="forkHandle"
+      joint_origin_xyz="0 0.005 0.0013"
+      joint_origin_rpy="-0.025 0 -0.0065"
+    />
 
-		<xacro:forque_assembly_link link_name="FTMount" link_mesh="2024_01_18_FTMount" mass="0.103" cog="0.010934 -0.138522 -0.05066">
-			<inertia ixx="0.00017623" iyy="0.000068428" iyz="-0.00001757133" izz="0.00021455" ixy="0.00000095729" ixz="-0.0000000562908"/>
-        </xacro:forque_assembly_link>
-	  	<xacro:forque_assembly_joint joint_name="FTMount_to_world" parent="${base_parent}" child="FTMount" joint_origin_xyz="0 0 -0.005" joint_origin_rpy="0 0 0"/>
+    <xacro:forque_assembly_link
+      link_name="forkHandleCover"
+      link_mesh="2024_06_24_forkHandleCover"
+      mass="0.004"
+      cog="0.011157 -0.168451 0.006404"
+    >
+      <inertia
+        ixx="0.0000027878"
+        iyy="0.00000064518"
+        iyz="0.00000016201"
+        izz="0.000003363634"
+        ixy="0.00000000012805"
+        ixz="0.00000000006585"
+      />
+    </xacro:forque_assembly_link>
+    <xacro:forque_assembly_joint
+      joint_name="forkHandleCover_to_forkHandle"
+      parent="forkHandle"
+      child="forkHandleCover"
+      joint_origin_xyz="0 0 0"
+      joint_origin_rpy="0 0 0"
+    />
 
-	  	<xacro:forque_assembly_link link_name="FT" link_mesh="2023_03_09_wirelessFT" mass="0.280" cog="0.0111446 -0.0882070 -0.0544936">
-	  		<inertia ixx="0.000543925" iyy="0.000165428" iyz="-0.00000001487288" izz="0.000691232" ixy="-0.00000128367" ixz="0"/>
-	  	</xacro:forque_assembly_link>
-	  	<xacro:forque_assembly_joint joint_name="FT_to_FTMount" parent="FTMount" child="FT" joint_origin_xyz="0 0 0" joint_origin_rpy="0 0 0"/>
+    <xacro:forque_assembly_link
+      link_name="forque"
+      link_mesh="ATI-9105-TW-NANO25-E"
+      mass="0.0634"
+      cog="0.0124692 0.0137169 0.010558"
+    >
+      <inertia
+        ixx="0.000005235822"
+        iyy="0.000006264852"
+        iyz="-0.00000004033694"
+        izz="0.00000640797"
+        ixy="-0.0000003129932"
+        ixz="0.000000013798"
+      />
+    </xacro:forque_assembly_link>
+    <xacro:forque_assembly_joint
+      joint_name="forque_to_forkHandle"
+      parent="forkHandle"
+      child="forque"
+      joint_origin_xyz="-0.00634 -0.222553 -0.004286"
+      joint_origin_rpy="${J_PI/2} ${J_PI/3} 0"
+    />
 
+    <xacro:forque_assembly_link
+      link_name="forkTine"
+      link_mesh="fork_tine"
+      mass="0.024"
+      cog="0.013090 0.0180789 0.0445231"
+    >
+      <inertia
+        ixx="0.0000098769"
+        iyy="0.000009848103"
+        iyz="0.00000057639"
+        izz="0.0000015674"
+        ixy="0.000000000806182"
+        ixz="-0.00000000296036"
+      />
+    </xacro:forque_assembly_link>
+    <xacro:forque_assembly_joint
+      joint_name="forkTine_to_forque"
+      parent="forque"
+      child="forkTine"
+      joint_origin_xyz="-0.0054 0.008 0.093"
+      joint_origin_rpy="0 ${J_PI} ${240*J_PI/180}"
+    />
 
-	  	<xacro:if value="${use_antenna}">
-		  	<xacro:forque_assembly_link link_name="FTAntenna" link_mesh="2023_03_09_wirelessFTAntenna" mass="0.018" cog="-0.0162965 0.0666626 -0.0545096">
-	  		  <xacro:insert_block name="default_inertial"/>
-	  	  </xacro:forque_assembly_link>
-	  	  <xacro:forque_assembly_joint joint_name="FTAntenna_to_FT" parent="FT" child="FTAntenna" joint_origin_xyz="0 0 0" joint_origin_rpy="0 0 0"/>
-		  </xacro:if>
-
-	  	<xacro:forque_assembly_link link_name="forkHandle" link_mesh="2024_06_24_forkHandleHollow" mass="0.028" cog="0.011097 -0.162629 -0.011948">
-	  		<inertia ixx="0.00003114" iyy="0.000011867" iyz="0.00000054005" izz="0.000038478" ixy="-0.00000050626" ixz="0.000000082271"/>
-	  	</xacro:forque_assembly_link>
-
-		<!-- The slight rotation was manually added due to empirical deformations in the robot gripped, such that the fingers and fork handle were slightly pitched up relative to the wrist. -->
-		<xacro:forque_assembly_joint joint_name="forkHandle_to_FTMount" parent="FTMount" child="forkHandle" joint_origin_xyz="0 0.005 0.0013" joint_origin_rpy="-0.025 0 -0.0065"/>
-
-		<xacro:forque_assembly_link link_name="forkHandleCover" link_mesh="2024_06_24_forkHandleCover" mass="0.004" cog="0.011157 -0.168451 0.006404">
-	  		<inertia ixx="0.0000027878" iyy="0.00000064518" iyz="0.00000016201" izz="0.000003363634" ixy="0.00000000012805" ixz="0.00000000006585"/>
-	  	</xacro:forque_assembly_link>
-		<xacro:forque_assembly_joint joint_name="forkHandleCover_to_forkHandle" parent="forkHandle" child="forkHandleCover" joint_origin_xyz="0 0 0" joint_origin_rpy="0 0 0"/>
-
-	  	<xacro:forque_assembly_link link_name="forque" link_mesh="ATI-9105-TW-NANO25-E" mass="0.0634" cog="0.0124692 0.0137169 0.010558">
-	  		<inertia ixx="0.000005235822" iyy="0.000006264852" iyz="-0.00000004033694" izz="0.00000640797" ixy="-0.0000003129932" ixz="0.000000013798"/>
-	  	</xacro:forque_assembly_link>
-	  	<xacro:forque_assembly_joint joint_name="forque_to_forkHandle" parent="forkHandle" child="forque" joint_origin_xyz="-0.00634 -0.222553 -0.004286" joint_origin_rpy="${J_PI/2} ${J_PI/3} 0"/>
-
-	  	<xacro:forque_assembly_link link_name="forkTine" link_mesh="fork_tine" mass="0.024" cog="0.013090 0.0180789 0.0445231">
-	  		<inertia ixx="0.0000098769" iyy="0.000009848103" iyz="0.00000057639" izz="0.0000015674" ixy="0.000000000806182" ixz="-0.00000000296036"/>
-	  	</xacro:forque_assembly_link>
-	  	<xacro:forque_assembly_joint joint_name="forkTine_to_forque" parent="forque" child="forkTine" joint_origin_xyz="-0.0054 0.008 0.093" joint_origin_rpy="0 ${J_PI} ${240*J_PI/180}"/>
-
-	  	<link name="forkTip" />
-	  	<joint name="forkTip_to_forkTine" type="fixed">
-		    <child link="forkTip"/>
-		    <parent link="forkTine"/>
-		    <origin rpy="${J_PI} 0 0" xyz="0.0135 0.007 0"/>
-		</joint>
-
-	</xacro:macro>
-
-
+    <link name="forkTip"/>
+    <joint
+      name="forkTip_to_forkTine"
+      type="fixed"
+    >
+      <child link="forkTip"/>
+      <parent link="forkTine"/>
+      <origin
+        rpy="${J_PI} 0 0"
+        xyz="0.0135 0.007 0"
+      />
+    </joint>
+  </xacro:macro>
 </root>

--- a/ada_description/urdf/forque/forque_standalone.xacro
+++ b/ada_description/urdf/forque/forque_standalone.xacro
@@ -1,35 +1,43 @@
 <?xml version="1.0"?>
-
-<robot xmlns:xi="http://www.w3.org/2001/XInclude"
+<robot
+  xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
-    xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
+  xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
   xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
   xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
-    xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
-    xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
+  xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
+  xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
   xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
   xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
   xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
-    xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
-    xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-  xmlns:xacro="http://www.ros.org/wiki/xacro" name="camera">
-
- <xacro:include filename="$(find ada_description)/urdf/forque/forque.xacro"/>
+  xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
+  xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
+  xmlns:xacro="http://www.ros.org/wiki/xacro"
+  name="camera"
+>
+  <xacro:include filename="$(find ada_description)/urdf/forque/forque.xacro"/>
 
   <link name="root"/>
 
   <!-- for gazebo -->
   <link name="world"/>
 
-  <joint name="connect_root_and_world" type="fixed">
-    <child link="root" />
-    <parent link="world" />
-    <origin xyz="0 0 0" rpy="0 0 0" />
+  <joint
+    name="connect_root_and_world"
+    type="fixed"
+  >
+    <child link="root"/>
+    <parent link="world"/>
+    <origin
+      xyz="0 0 0"
+      rpy="0 0 0"
+    />
   </joint>
 
-  <xacro:property name="robot_root" value="root" />
+  <xacro:property
+    name="robot_root"
+    value="root"
+  />
 
   <xacro:forque_assembly base_parent="${robot_root}"/>
-
-
 </robot>

--- a/ada_description/urdf/j2n6s200.xacro
+++ b/ada_description/urdf/j2n6s200.xacro
@@ -1,148 +1,477 @@
 <?xml version="1.0"?>
 <!-- j2_6n refers to jaco v2 6DOF non-spherical -->
+<root
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
+  xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
+  xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+  xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
+  xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
+  xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
+  xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+  xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+  xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
+  xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
+  xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
+  xmlns:xacro="http://www.ros.org/wiki/xacro"
+>
+  <xacro:include filename="$(find ada_description)/urdf/kinova_common.xacro"/>
+  <xacro:include filename="$(find ada_description)/urdf/kinova_finger_set.xacro"/>
 
+  <!-- Import all Gazebo-customization elements -->
+  <xacro:include filename="$(find ada_description)/urdf/kinova.gazebo"/>
 
-<root xmlns:xi="http://www.w3.org/2001/XInclude"
-    xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
-    xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
-    xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-    xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
-    xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
-    xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
-    xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-    xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
-    xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
-    xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
-    xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-    xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:property
+    name="link_base_mesh"
+    value="base"
+  />
+  <xacro:property
+    name="link_1_mesh"
+    value="shoulder"
+  />
+  <xacro:property
+    name="link_2_mesh"
+    value="arm"
+  />
+  <xacro:property
+    name="link_3_mesh"
+    value="forearm"
+  />
+  <xacro:property
+    name="link_4_mesh"
+    value="wrist"
+  />
+  <xacro:property
+    name="link_5_mesh"
+    value="wrist"
+  />
+  <xacro:property
+    name="link_6_mesh"
+    value="hand_2finger"
+  />
 
-    <xacro:include filename="$(find ada_description)/urdf/kinova_common.xacro" />
-    <xacro:include filename="$(find ada_description)/urdf/kinova_finger_set.xacro" />
-
-    <!-- Import all Gazebo-customization elements -->
-    <xacro:include filename="$(find ada_description)/urdf/kinova.gazebo" />
-
-    <xacro:property name="link_base_mesh" value="base" />
-    <xacro:property name="link_1_mesh" value="shoulder" />
-    <xacro:property name="link_2_mesh" value="arm" />
-    <xacro:property name="link_3_mesh" value="forearm" />
-    <xacro:property name="link_4_mesh" value="wrist" />
-    <xacro:property name="link_5_mesh" value="wrist" />
-    <xacro:property name="link_6_mesh" value="hand_2finger" />
-
-    <!--Used for conditional arguments for setting inertial parameters
+  <!--Used for conditional arguments for setting inertial parameters
         base 0, shoulder 1, arm 2, forearm 3, wrist 4, arm_mico 5,
         arm_half1 (7dof)	6, arm_half2 (7dof) 7, wrist_spherical_1  8, wrist_spherical_2  9
         fore_arm_mico 10,
         hand 3 finger 55, hand_2finger 56, finger_proximal 57, finger_distal 58
     -->
-    <xacro:property name="link_base_mesh_no" value="0" />
-    <xacro:property name="link_1_mesh_no" value="1" />
-    <xacro:property name="link_2_mesh_no" value="2" />
-    <xacro:property name="link_3_mesh_no" value="3" />
-    <xacro:property name="link_4_mesh_no" value="4" />
-    <xacro:property name="link_5_mesh_no" value="4" />
-    <xacro:property name="link_6_mesh_no" value="56" />
+  <xacro:property
+    name="link_base_mesh_no"
+    value="0"
+  />
+  <xacro:property
+    name="link_1_mesh_no"
+    value="1"
+  />
+  <xacro:property
+    name="link_2_mesh_no"
+    value="2"
+  />
+  <xacro:property
+    name="link_3_mesh_no"
+    value="3"
+  />
+  <xacro:property
+    name="link_4_mesh_no"
+    value="4"
+  />
+  <xacro:property
+    name="link_5_mesh_no"
+    value="4"
+  />
+  <xacro:property
+    name="link_6_mesh_no"
+    value="56"
+  />
 
-    <xacro:property name="joint_base" value="joint_base" />
-    <xacro:property name="joint_base_type" value="fixed" />
-    <xacro:property name="joint_base_axis_xyz" value="0 0 0" />
-    <xacro:property name="joint_base_origin_xyz" value="0 0 0" />
-    <xacro:property name="joint_base_origin_rpy" value="0 0 0" />
+  <xacro:property
+    name="joint_base"
+    value="joint_base"
+  />
+  <xacro:property
+    name="joint_base_type"
+    value="fixed"
+  />
+  <xacro:property
+    name="joint_base_axis_xyz"
+    value="0 0 0"
+  />
+  <xacro:property
+    name="joint_base_origin_xyz"
+    value="0 0 0"
+  />
+  <xacro:property
+    name="joint_base_origin_rpy"
+    value="0 0 0"
+  />
 
-    <xacro:property name="joint_1" value="joint_1" />
-    <xacro:property name="joint_1_type" value="continuous" />
-    <xacro:property name="joint_1_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_1_origin_xyz" value="0 0 0.15675" />
-    <xacro:property name="joint_1_origin_rpy" value="0 ${J_PI} 0" />
-    <xacro:property name="joint_1_velocity_limit" value="${36*J_PI/180}" />
-    <xacro:property name="joint_1_torque_limit" value="40" />
+  <xacro:property
+    name="joint_1"
+    value="joint_1"
+  />
+  <xacro:property
+    name="joint_1_type"
+    value="continuous"
+  />
+  <xacro:property
+    name="joint_1_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_1_origin_xyz"
+    value="0 0 0.15675"
+  />
+  <xacro:property
+    name="joint_1_origin_rpy"
+    value="0 ${J_PI} 0"
+  />
+  <xacro:property
+    name="joint_1_velocity_limit"
+    value="${36*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_1_torque_limit"
+    value="40"
+  />
 
-    <xacro:property name="joint_2" value="joint_2" />
-    <xacro:property name="joint_2_type" value="revolute" />
-    <xacro:property name="joint_2_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_2_origin_xyz" value="0 0.0016 -0.11875" />
-    <xacro:property name="joint_2_origin_rpy" value="-${J_PI/2} 0 ${J_PI}" />
-    <xacro:property name="joint_2_lower_limit" value="${47/180*J_PI}" />
-    <xacro:property name="joint_2_upper_limit" value="${313/180*J_PI}" />
-    <xacro:property name="joint_2_velocity_limit" value="${36*J_PI/180}" />
-    <xacro:property name="joint_2_torque_limit" value="80" />
+  <xacro:property
+    name="joint_2"
+    value="joint_2"
+  />
+  <xacro:property
+    name="joint_2_type"
+    value="revolute"
+  />
+  <xacro:property
+    name="joint_2_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_2_origin_xyz"
+    value="0 0.0016 -0.11875"
+  />
+  <xacro:property
+    name="joint_2_origin_rpy"
+    value="-${J_PI/2} 0 ${J_PI}"
+  />
+  <xacro:property
+    name="joint_2_lower_limit"
+    value="${47/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_2_upper_limit"
+    value="${313/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_2_velocity_limit"
+    value="${36*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_2_torque_limit"
+    value="80"
+  />
 
-    <xacro:property name="joint_3" value="joint_3" />
-    <xacro:property name="joint_3_type" value="revolute" />
-    <xacro:property name="joint_3_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_3_origin_xyz" value="0 -0.410 0" />
-    <xacro:property name="joint_3_origin_rpy" value="0 ${J_PI} 0" />
-    <xacro:property name="joint_3_lower_limit" value="${19/180*J_PI}" />
-    <xacro:property name="joint_3_upper_limit" value="${341/180*J_PI}" />
-    <xacro:property name="joint_3_velocity_limit" value="${36*J_PI/180}" />
-    <xacro:property name="joint_3_torque_limit" value="40" />
+  <xacro:property
+    name="joint_3"
+    value="joint_3"
+  />
+  <xacro:property
+    name="joint_3_type"
+    value="revolute"
+  />
+  <xacro:property
+    name="joint_3_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_3_origin_xyz"
+    value="0 -0.410 0"
+  />
+  <xacro:property
+    name="joint_3_origin_rpy"
+    value="0 ${J_PI} 0"
+  />
+  <xacro:property
+    name="joint_3_lower_limit"
+    value="${19/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_3_upper_limit"
+    value="${341/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_3_velocity_limit"
+    value="${36*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_3_torque_limit"
+    value="40"
+  />
 
-    <xacro:property name="joint_4" value="joint_4" />
-    <xacro:property name="joint_4_type" value="continuous" />
-    <xacro:property name="joint_4_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_4_origin_xyz" value="0 0.2073 -0.0114" />
-    <xacro:property name="joint_4_origin_rpy" value="-${J_PI/2} 0 ${J_PI}" />
-    <xacro:property name="joint_4_velocity_limit" value="${48*J_PI/180}" />
-    <xacro:property name="joint_4_torque_limit" value="20" />
+  <xacro:property
+    name="joint_4"
+    value="joint_4"
+  />
+  <xacro:property
+    name="joint_4_type"
+    value="continuous"
+  />
+  <xacro:property
+    name="joint_4_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_4_origin_xyz"
+    value="0 0.2073 -0.0114"
+  />
+  <xacro:property
+    name="joint_4_origin_rpy"
+    value="-${J_PI/2} 0 ${J_PI}"
+  />
+  <xacro:property
+    name="joint_4_velocity_limit"
+    value="${48*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_4_torque_limit"
+    value="20"
+  />
 
-    <xacro:property name="joint_5" value="joint_5" />
-    <xacro:property name="joint_5_type" value="continuous" />
-    <xacro:property name="joint_5_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_5_origin_xyz" value="0 -0.03703 -0.06414" />
-    <xacro:property name="joint_5_origin_rpy" value="${J_PI/3} 0 ${J_PI}" />
-    <xacro:property name="joint_5_velocity_limit" value="${48*J_PI/180}" />
-    <xacro:property name="joint_5_torque_limit" value="20" />
+  <xacro:property
+    name="joint_5"
+    value="joint_5"
+  />
+  <xacro:property
+    name="joint_5_type"
+    value="continuous"
+  />
+  <xacro:property
+    name="joint_5_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_5_origin_xyz"
+    value="0 -0.03703 -0.06414"
+  />
+  <xacro:property
+    name="joint_5_origin_rpy"
+    value="${J_PI/3} 0 ${J_PI}"
+  />
+  <xacro:property
+    name="joint_5_velocity_limit"
+    value="${48*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_5_torque_limit"
+    value="20"
+  />
 
-    <xacro:property name="joint_6" value="joint_6" />
-    <xacro:property name="joint_6_type" value="continuous" />
-    <xacro:property name="joint_6_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_6_origin_xyz" value="0 -0.03703 -0.06414" />
-    <xacro:property name="joint_6_origin_rpy" value="${J_PI/3} 0 ${J_PI}" />
-    <!-- If gripper inverted, use this line instead -->
-    <!-- <xacro:property name="joint_6_origin_rpy" value="$${-J_PI/3} 0 0" /> -->
-    <xacro:property name="joint_6_velocity_limit" value="${48*J_PI/180}" />
-    <xacro:property name="joint_6_torque_limit" value="20" />
+  <xacro:property
+    name="joint_6"
+    value="joint_6"
+  />
+  <xacro:property
+    name="joint_6_type"
+    value="continuous"
+  />
+  <xacro:property
+    name="joint_6_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_6_origin_xyz"
+    value="0 -0.03703 -0.06414"
+  />
+  <xacro:property
+    name="joint_6_origin_rpy"
+    value="${J_PI/3} 0 ${J_PI}"
+  />
+  <!-- If gripper inverted, use this line instead -->
+  <!-- <xacro:property name="joint_6_origin_rpy" value="$${-J_PI/3} 0 0" /> -->
+  <xacro:property
+    name="joint_6_velocity_limit"
+    value="${48*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_6_torque_limit"
+    value="20"
+  />
 
-    <xacro:property name="joint_end_effector" value="end_effector_offset" />
-    <xacro:property name="joint_end_effector_type" value="fixed" />
-    <xacro:property name="joint_end_effector_axis_xyz" value="0 0 0" />
-    <xacro:property name="joint_end_effector_origin_xyz" value="0 0 -0.1600" />
-    <xacro:property name="joint_end_effector_origin_rpy" value="${J_PI} 0 ${J_PI/2}" />
+  <xacro:property
+    name="joint_end_effector"
+    value="end_effector_offset"
+  />
+  <xacro:property
+    name="joint_end_effector_type"
+    value="fixed"
+  />
+  <xacro:property
+    name="joint_end_effector_axis_xyz"
+    value="0 0 0"
+  />
+  <xacro:property
+    name="joint_end_effector_origin_xyz"
+    value="0 0 -0.1600"
+  />
+  <xacro:property
+    name="joint_end_effector_origin_rpy"
+    value="${J_PI} 0 ${J_PI/2}"
+  />
 
+  <xacro:macro
+    name="j2n6s200"
+    params="base_parent prefix:=j2n6s200"
+  >
+    <xacro:gazebo_config robot_namespace="${prefix}"/>
 
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_base"
+      link_mesh="${link_base_mesh}"
+      mesh_no="${link_base_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_base"
+      type="${joint_base_type}"
+      parent="${base_parent}"
+      child="${prefix}_link_base"
+      joint_axis_xyz="${joint_base_axis_xyz}"
+      joint_origin_xyz="${joint_base_origin_xyz}"
+      joint_origin_rpy="${joint_base_origin_rpy}"
+      fixed="true"
+    />
 
-    <xacro:macro name="j2n6s200" params="base_parent prefix:=j2n6s200">
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_1"
+      link_mesh="${link_1_mesh}"
+      use_ring_mesh="true"
+      mesh_no="${link_1_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_1"
+      type="${joint_1_type}"
+      parent="${prefix}_link_base"
+      child="${prefix}_link_1"
+      joint_axis_xyz="${joint_1_axis_xyz}"
+      joint_origin_xyz="${joint_1_origin_xyz}"
+      joint_origin_rpy="${joint_1_origin_rpy}"
+      joint_velocity_limit="${joint_1_velocity_limit}"
+      joint_torque_limit="${joint_1_torque_limit}"
+    />
 
-        <xacro:gazebo_config robot_namespace="${prefix}"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_2"
+      link_mesh="${link_2_mesh}"
+      use_ring_mesh="true"
+      mesh_no="${link_2_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_2"
+      type="${joint_2_type}"
+      parent="${prefix}_link_1"
+      child="${prefix}_link_2"
+      joint_axis_xyz="${joint_2_axis_xyz}"
+      joint_origin_xyz="${joint_2_origin_xyz}"
+      joint_origin_rpy="${joint_2_origin_rpy}"
+      joint_lower_limit="${joint_2_lower_limit}"
+      joint_upper_limit="${joint_2_upper_limit}"
+      joint_velocity_limit="${joint_2_velocity_limit}"
+      joint_torque_limit="${joint_2_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_base" link_mesh="${link_base_mesh}" mesh_no="${link_base_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_base" type="${joint_base_type}" parent="${base_parent}" child="${prefix}_link_base" joint_axis_xyz="${joint_base_axis_xyz}" joint_origin_xyz="${joint_base_origin_xyz}" joint_origin_rpy="${joint_base_origin_rpy}" fixed="true"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_3"
+      link_mesh="${link_3_mesh}"
+      use_ring_mesh="true"
+      mesh_no="${link_3_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_3"
+      type="${joint_3_type}"
+      parent="${prefix}_link_2"
+      child="${prefix}_link_3"
+      joint_axis_xyz="${joint_3_axis_xyz}"
+      joint_origin_xyz="${joint_3_origin_xyz}"
+      joint_origin_rpy="${joint_3_origin_rpy}"
+      joint_lower_limit="${joint_3_lower_limit}"
+      joint_upper_limit="${joint_3_upper_limit}"
+      joint_velocity_limit="${joint_3_velocity_limit}"
+      joint_torque_limit="${joint_3_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_1" link_mesh="${link_1_mesh}" use_ring_mesh="true" mesh_no="${link_1_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_1" type="${joint_1_type}" parent="${prefix}_link_base" child="${prefix}_link_1" joint_axis_xyz="${joint_1_axis_xyz}" joint_origin_xyz="${joint_1_origin_xyz}" joint_origin_rpy="${joint_1_origin_rpy}" joint_velocity_limit="${joint_1_velocity_limit}" joint_torque_limit="${joint_1_torque_limit}"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_4"
+      link_mesh="${link_4_mesh}"
+      use_ring_mesh="true"
+      ring_mesh="ring_small"
+      mesh_no="${link_4_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_4"
+      type="${joint_4_type}"
+      parent="${prefix}_link_3"
+      child="${prefix}_link_4"
+      joint_axis_xyz="${joint_4_axis_xyz}"
+      joint_origin_xyz="${joint_4_origin_xyz}"
+      joint_origin_rpy="${joint_4_origin_rpy}"
+      joint_velocity_limit="${joint_4_velocity_limit}"
+      joint_torque_limit="${joint_4_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_2" link_mesh="${link_2_mesh}" use_ring_mesh="true" mesh_no="${link_2_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_2" type="${joint_2_type}" parent="${prefix}_link_1" child="${prefix}_link_2" joint_axis_xyz="${joint_2_axis_xyz}" joint_origin_xyz="${joint_2_origin_xyz}" joint_origin_rpy="${joint_2_origin_rpy}" joint_lower_limit="${joint_2_lower_limit}" joint_upper_limit="${joint_2_upper_limit}" joint_velocity_limit="${joint_2_velocity_limit}" joint_torque_limit="${joint_2_torque_limit}"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_5"
+      link_mesh="${link_5_mesh}"
+      use_ring_mesh="true"
+      ring_mesh="ring_small"
+      mesh_no="${link_5_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_5"
+      type="${joint_5_type}"
+      parent="${prefix}_link_4"
+      child="${prefix}_link_5"
+      joint_axis_xyz="${joint_5_axis_xyz}"
+      joint_origin_xyz="${joint_5_origin_xyz}"
+      joint_origin_rpy="${joint_5_origin_rpy}"
+      joint_velocity_limit="${joint_5_velocity_limit}"
+      joint_torque_limit="${joint_5_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_3" link_mesh="${link_3_mesh}" use_ring_mesh="true" mesh_no="${link_3_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_3" type="${joint_3_type}" parent="${prefix}_link_2" child="${prefix}_link_3" joint_axis_xyz="${joint_3_axis_xyz}" joint_origin_xyz="${joint_3_origin_xyz}" joint_origin_rpy="${joint_3_origin_rpy}" joint_lower_limit="${joint_3_lower_limit}" joint_upper_limit="${joint_3_upper_limit}" joint_velocity_limit="${joint_3_velocity_limit}" joint_torque_limit="${joint_3_torque_limit}"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_6"
+      link_mesh="${link_6_mesh}"
+      use_ring_mesh="true"
+      ring_mesh="ring_small"
+      mesh_no="${link_6_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_6"
+      type="${joint_6_type}"
+      parent="${prefix}_link_5"
+      child="${prefix}_link_6"
+      joint_axis_xyz="${joint_6_axis_xyz}"
+      joint_origin_xyz="${joint_6_origin_xyz}"
+      joint_origin_rpy="${joint_6_origin_rpy}"
+      joint_velocity_limit="${joint_6_velocity_limit}"
+      joint_torque_limit="${joint_6_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_4" link_mesh="${link_4_mesh}" use_ring_mesh="true" ring_mesh="ring_small" mesh_no="${link_4_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_4" type="${joint_4_type}" parent="${prefix}_link_3" child="${prefix}_link_4" joint_axis_xyz="${joint_4_axis_xyz}" joint_origin_xyz="${joint_4_origin_xyz}" joint_origin_rpy="${joint_4_origin_rpy}" joint_velocity_limit="${joint_4_velocity_limit}" joint_torque_limit="${joint_4_torque_limit}"/>
+    <xacro:kinova_virtual_link link_name="${prefix}_end_effector"/>
+    <xacro:kinova_virtual_joint
+      joint_name="${prefix}_joint_end_effector"
+      type="${joint_end_effector_type}"
+      parent="${prefix}_link_6"
+      child="${prefix}_end_effector"
+      joint_axis_xyz="${joint_end_effector_axis_xyz}"
+      joint_origin_xyz="${joint_end_effector_origin_xyz}"
+      joint_origin_rpy="${joint_end_effector_origin_rpy}"
+      joint_lower_limit="0"
+      joint_upper_limit="0"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_5" link_mesh="${link_5_mesh}" use_ring_mesh="true" ring_mesh="ring_small" mesh_no="${link_5_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_5" type="${joint_5_type}" parent="${prefix}_link_4" child="${prefix}_link_5" joint_axis_xyz="${joint_5_axis_xyz}" joint_origin_xyz="${joint_5_origin_xyz}" joint_origin_rpy="${joint_5_origin_rpy}" joint_velocity_limit="${joint_5_velocity_limit}" joint_torque_limit="${joint_5_torque_limit}"/>
-
-        <xacro:kinova_armlink link_name="${prefix}_link_6" link_mesh="${link_6_mesh}" use_ring_mesh="true" ring_mesh="ring_small" mesh_no="${link_6_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_6" type="${joint_6_type}" parent="${prefix}_link_5" child="${prefix}_link_6" joint_axis_xyz="${joint_6_axis_xyz}" joint_origin_xyz="${joint_6_origin_xyz}" joint_origin_rpy="${joint_6_origin_rpy}" joint_velocity_limit="${joint_6_velocity_limit}" joint_torque_limit="${joint_6_torque_limit}"/>
-
-
-        <xacro:kinova_virtual_link link_name="${prefix}_end_effector"/>
-        <xacro:kinova_virtual_joint joint_name="${prefix}_joint_end_effector" type="${joint_end_effector_type}" parent="${prefix}_link_6" child="${prefix}_end_effector" joint_axis_xyz="${joint_end_effector_axis_xyz}" joint_origin_xyz="${joint_end_effector_origin_xyz}" joint_origin_rpy="${joint_end_effector_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0"/>
-
-    <xacro:kinova_2fingers link_hand="${prefix}_link_6" prefix="${prefix}_"/>
-    </xacro:macro>
-
-
+    <xacro:kinova_2fingers
+      link_hand="${prefix}_link_6"
+      prefix="${prefix}_"
+    />
+  </xacro:macro>
 </root>

--- a/ada_description/urdf/j2n6s200_standalone.xacro
+++ b/ada_description/urdf/j2n6s200_standalone.xacro
@@ -1,22 +1,21 @@
 <?xml version="1.0"?>
 <!-- j2n6s200 refers to jaco v2 6DOF non-spherical 2fingers -->
-
-
-<robot xmlns:xi="http://www.w3.org/2001/XInclude"
-	xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
-    xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
-	xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-	xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
-    xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
-    xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
-	xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-	xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
-	xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
-    xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
-    xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-	xmlns:xacro="http://www.ros.org/wiki/xacro" name="j2n6s200">
-
-
+<robot
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
+  xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
+  xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+  xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
+  xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
+  xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
+  xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+  xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+  xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
+  xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
+  xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
+  xmlns:xacro="http://www.ros.org/wiki/xacro"
+  name="j2n6s200"
+>
   <xacro:include filename="$(find ada_description)/urdf/j2n6s200.xacro"/>
 
   <link name="root"/>
@@ -24,14 +23,22 @@
   <!-- for gazebo -->
   <link name="world"/>
 
-  <joint name="connect_root_and_world" type="fixed">
-    <child link="root" />
-    <parent link="world" />
-    <origin xyz="0 0 0" rpy="0 0 0" />
+  <joint
+    name="connect_root_and_world"
+    type="fixed"
+  >
+    <child link="root"/>
+    <parent link="world"/>
+    <origin
+      xyz="0 0 0"
+      rpy="0 0 0"
+    />
   </joint>
 
-  <xacro:property name="robot_root" value="root" />
+  <xacro:property
+    name="robot_root"
+    value="root"
+  />
 
-  <xacro:j2n6s200  base_parent="${robot_root}"/>
-
+  <xacro:j2n6s200 base_parent="${robot_root}"/>
 </robot>

--- a/ada_description/urdf/j2n6s300.xacro
+++ b/ada_description/urdf/j2n6s300.xacro
@@ -1,156 +1,521 @@
 <?xml version="1.0"?>
 <!-- j2_6n refers to jaco v2 6DOF non-spherical -->
+<root
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
+  xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
+  xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+  xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
+  xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
+  xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
+  xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+  xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+  xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
+  xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
+  xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
+  xmlns:xacro="http://www.ros.org/wiki/xacro"
+>
+  <xacro:include filename="$(find ada_description)/urdf/kinova_common.xacro"/>
+  <xacro:include filename="$(find ada_description)/urdf/kinova_finger_set.xacro"/>
 
+  <!-- Import all Gazebo-customization elements -->
+  <xacro:include filename="$(find ada_description)/urdf/kinova.gazebo"/>
 
-<root xmlns:xi="http://www.w3.org/2001/XInclude"
-    xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
-    xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
-    xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-    xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
-    xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
-    xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
-    xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-    xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
-    xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
-    xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
-    xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-    xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:property
+    name="link_base_mesh"
+    value="base"
+  />
+  <xacro:property
+    name="link_1_mesh"
+    value="shoulder"
+  />
+  <xacro:property
+    name="link_2_mesh"
+    value="arm"
+  />
+  <xacro:property
+    name="link_3_mesh"
+    value="forearm"
+  />
+  <xacro:property
+    name="link_4_mesh"
+    value="wrist"
+  />
+  <xacro:property
+    name="link_5_mesh"
+    value="wrist"
+  />
+  <xacro:property
+    name="link_6_mesh"
+    value="hand_3finger"
+  />
 
-    <xacro:include filename="$(find ada_description)/urdf/kinova_common.xacro" />
-    <xacro:include filename="$(find ada_description)/urdf/kinova_finger_set.xacro" />
-
-    <!-- Import all Gazebo-customization elements -->
-    <xacro:include filename="$(find ada_description)/urdf/kinova.gazebo" />
-
-    <xacro:property name="link_base_mesh" value="base" />
-    <xacro:property name="link_1_mesh" value="shoulder" />
-    <xacro:property name="link_2_mesh" value="arm" />
-    <xacro:property name="link_3_mesh" value="forearm" />
-    <xacro:property name="link_4_mesh" value="wrist" />
-    <xacro:property name="link_5_mesh" value="wrist" />
-    <xacro:property name="link_6_mesh" value="hand_3finger" />
-
-    <!--Used for conditional arguments for setting inertial parameters
+  <!--Used for conditional arguments for setting inertial parameters
         base 0, shoulder 1, arm 2, forearm 3, wrist 4, arm_mico 5,
         arm_half1 (7dof)	6, arm_half2 (7dof) 7, wrist_spherical_1  8, wrist_spherical_2  9
         fore_arm_mico 10,
         hand 3 finger 55, hand_2finger 56, finger_proximal 57, finger_distal 58
     -->
-    <xacro:property name="link_base_mesh_no" value="0" />
-    <xacro:property name="link_1_mesh_no" value="1" />
-    <xacro:property name="link_2_mesh_no" value="2" />
-    <xacro:property name="link_3_mesh_no" value="3" />
-    <xacro:property name="link_4_mesh_no" value="4" />
-    <xacro:property name="link_5_mesh_no" value="4" />
-    <xacro:property name="link_6_mesh_no" value="55" />
+  <xacro:property
+    name="link_base_mesh_no"
+    value="0"
+  />
+  <xacro:property
+    name="link_1_mesh_no"
+    value="1"
+  />
+  <xacro:property
+    name="link_2_mesh_no"
+    value="2"
+  />
+  <xacro:property
+    name="link_3_mesh_no"
+    value="3"
+  />
+  <xacro:property
+    name="link_4_mesh_no"
+    value="4"
+  />
+  <xacro:property
+    name="link_5_mesh_no"
+    value="4"
+  />
+  <xacro:property
+    name="link_6_mesh_no"
+    value="55"
+  />
 
-    <xacro:property name="joint_base" value="joint_base" />
-    <xacro:property name="joint_base_type" value="fixed" />
-    <xacro:property name="joint_base_axis_xyz" value="0 0 0" />
-    <xacro:property name="joint_base_origin_xyz" value="0 0 0" />
-    <xacro:property name="joint_base_origin_rpy" value="0 0 0" />
+  <xacro:property
+    name="joint_base"
+    value="joint_base"
+  />
+  <xacro:property
+    name="joint_base_type"
+    value="fixed"
+  />
+  <xacro:property
+    name="joint_base_axis_xyz"
+    value="0 0 0"
+  />
+  <xacro:property
+    name="joint_base_origin_xyz"
+    value="0 0 0"
+  />
+  <xacro:property
+    name="joint_base_origin_rpy"
+    value="0 0 0"
+  />
 
-    <xacro:property name="joint_1" value="joint_1" />
-    <xacro:property name="joint_1_type" value="continuous" />
-    <xacro:property name="joint_1_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_1_origin_xyz" value="0 0 0.15675" />
-    <xacro:property name="joint_1_origin_rpy" value="0 ${J_PI} 0" />
-    <xacro:property name="joint_1_lower_limit" value="${-2*J_PI}" />
-    <xacro:property name="joint_1_upper_limit" value="${2*J_PI}" />
-    <xacro:property name="joint_1_velocity_limit" value="${36*J_PI/180}" />
-    <xacro:property name="joint_1_torque_limit" value="40" />
+  <xacro:property
+    name="joint_1"
+    value="joint_1"
+  />
+  <xacro:property
+    name="joint_1_type"
+    value="continuous"
+  />
+  <xacro:property
+    name="joint_1_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_1_origin_xyz"
+    value="0 0 0.15675"
+  />
+  <xacro:property
+    name="joint_1_origin_rpy"
+    value="0 ${J_PI} 0"
+  />
+  <xacro:property
+    name="joint_1_lower_limit"
+    value="${-2*J_PI}"
+  />
+  <xacro:property
+    name="joint_1_upper_limit"
+    value="${2*J_PI}"
+  />
+  <xacro:property
+    name="joint_1_velocity_limit"
+    value="${36*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_1_torque_limit"
+    value="40"
+  />
 
-    <xacro:property name="joint_2" value="joint_2" />
-    <xacro:property name="joint_2_type" value="revolute" />
-    <xacro:property name="joint_2_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_2_origin_xyz" value="0 0.0016 -0.11875" />
-    <xacro:property name="joint_2_origin_rpy" value="-${J_PI/2} 0 ${J_PI}" />
-    <xacro:property name="joint_2_lower_limit" value="${47/180*J_PI}" />
-    <xacro:property name="joint_2_upper_limit" value="${313/180*J_PI}" />
-    <xacro:property name="joint_2_velocity_limit" value="${36*J_PI/180}" />
-    <xacro:property name="joint_2_torque_limit" value="80" />
+  <xacro:property
+    name="joint_2"
+    value="joint_2"
+  />
+  <xacro:property
+    name="joint_2_type"
+    value="revolute"
+  />
+  <xacro:property
+    name="joint_2_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_2_origin_xyz"
+    value="0 0.0016 -0.11875"
+  />
+  <xacro:property
+    name="joint_2_origin_rpy"
+    value="-${J_PI/2} 0 ${J_PI}"
+  />
+  <xacro:property
+    name="joint_2_lower_limit"
+    value="${47/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_2_upper_limit"
+    value="${313/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_2_velocity_limit"
+    value="${36*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_2_torque_limit"
+    value="80"
+  />
 
-    <xacro:property name="joint_3" value="joint_3" />
-    <xacro:property name="joint_3_type" value="revolute" />
-    <xacro:property name="joint_3_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_3_origin_xyz" value="0 -0.410 0" />
-    <xacro:property name="joint_3_origin_rpy" value="0 ${J_PI} 0" />
-    <xacro:property name="joint_3_lower_limit" value="${19/180*J_PI}" />
-    <xacro:property name="joint_3_upper_limit" value="${341/180*J_PI}" />
-    <xacro:property name="joint_3_velocity_limit" value="${36*J_PI/180}" />
-    <xacro:property name="joint_3_torque_limit" value="40" />
+  <xacro:property
+    name="joint_3"
+    value="joint_3"
+  />
+  <xacro:property
+    name="joint_3_type"
+    value="revolute"
+  />
+  <xacro:property
+    name="joint_3_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_3_origin_xyz"
+    value="0 -0.410 0"
+  />
+  <xacro:property
+    name="joint_3_origin_rpy"
+    value="0 ${J_PI} 0"
+  />
+  <xacro:property
+    name="joint_3_lower_limit"
+    value="${19/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_3_upper_limit"
+    value="${341/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_3_velocity_limit"
+    value="${36*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_3_torque_limit"
+    value="40"
+  />
 
-    <xacro:property name="joint_4" value="joint_4" />
-    <xacro:property name="joint_4_type" value="continuous" />
-    <xacro:property name="joint_4_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_4_origin_xyz" value="0 0.2073 -0.0114" />
-    <xacro:property name="joint_4_origin_rpy" value="-${J_PI/2} 0 ${J_PI}" />
-    <xacro:property name="joint_4_lower_limit" value="${-2*J_PI}" />
-    <xacro:property name="joint_4_upper_limit" value="${2*J_PI}" />
-    <xacro:property name="joint_4_velocity_limit" value="${48*J_PI/180}" />
-    <xacro:property name="joint_4_torque_limit" value="20" />
+  <xacro:property
+    name="joint_4"
+    value="joint_4"
+  />
+  <xacro:property
+    name="joint_4_type"
+    value="continuous"
+  />
+  <xacro:property
+    name="joint_4_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_4_origin_xyz"
+    value="0 0.2073 -0.0114"
+  />
+  <xacro:property
+    name="joint_4_origin_rpy"
+    value="-${J_PI/2} 0 ${J_PI}"
+  />
+  <xacro:property
+    name="joint_4_lower_limit"
+    value="${-2*J_PI}"
+  />
+  <xacro:property
+    name="joint_4_upper_limit"
+    value="${2*J_PI}"
+  />
+  <xacro:property
+    name="joint_4_velocity_limit"
+    value="${48*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_4_torque_limit"
+    value="20"
+  />
 
-    <xacro:property name="joint_5" value="joint_5" />
-    <xacro:property name="joint_5_type" value="continuous" />
-    <xacro:property name="joint_5_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_5_origin_xyz" value="0 -0.03703 -0.06414" />
-    <xacro:property name="joint_5_origin_rpy" value="${J_PI/3} 0 ${J_PI}" />
-    <xacro:property name="joint_5_lower_limit" value="${-2*J_PI}" />
-    <xacro:property name="joint_5_upper_limit" value="${2*J_PI}" />
-    <xacro:property name="joint_5_velocity_limit" value="${48*J_PI/180}" />
-    <xacro:property name="joint_5_torque_limit" value="20" />
+  <xacro:property
+    name="joint_5"
+    value="joint_5"
+  />
+  <xacro:property
+    name="joint_5_type"
+    value="continuous"
+  />
+  <xacro:property
+    name="joint_5_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_5_origin_xyz"
+    value="0 -0.03703 -0.06414"
+  />
+  <xacro:property
+    name="joint_5_origin_rpy"
+    value="${J_PI/3} 0 ${J_PI}"
+  />
+  <xacro:property
+    name="joint_5_lower_limit"
+    value="${-2*J_PI}"
+  />
+  <xacro:property
+    name="joint_5_upper_limit"
+    value="${2*J_PI}"
+  />
+  <xacro:property
+    name="joint_5_velocity_limit"
+    value="${48*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_5_torque_limit"
+    value="20"
+  />
 
-    <xacro:property name="joint_6" value="joint_6" />
-    <xacro:property name="joint_6_type" value="continuous" />
-    <xacro:property name="joint_6_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_6_origin_xyz" value="0 -0.03703 -0.06414" />
-    <xacro:property name="joint_6_origin_rpy" value="${J_PI/3} 0 ${J_PI}" />
-    <!-- If gripper inverted, use this line instead -->
-    <!-- <xacro:property name="joint_6_origin_rpy" value="$${-J_PI/3} 0 0" /> -->
-    <xacro:property name="joint_6_lower_limit" value="${-2*J_PI}" />
-    <xacro:property name="joint_6_upper_limit" value="${2*J_PI}" />
-    <xacro:property name="joint_6_velocity_limit" value="${48*J_PI/180}" />
-    <xacro:property name="joint_6_torque_limit" value="20" />
+  <xacro:property
+    name="joint_6"
+    value="joint_6"
+  />
+  <xacro:property
+    name="joint_6_type"
+    value="continuous"
+  />
+  <xacro:property
+    name="joint_6_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_6_origin_xyz"
+    value="0 -0.03703 -0.06414"
+  />
+  <xacro:property
+    name="joint_6_origin_rpy"
+    value="${J_PI/3} 0 ${J_PI}"
+  />
+  <!-- If gripper inverted, use this line instead -->
+  <!-- <xacro:property name="joint_6_origin_rpy" value="$${-J_PI/3} 0 0" /> -->
+  <xacro:property
+    name="joint_6_lower_limit"
+    value="${-2*J_PI}"
+  />
+  <xacro:property
+    name="joint_6_upper_limit"
+    value="${2*J_PI}"
+  />
+  <xacro:property
+    name="joint_6_velocity_limit"
+    value="${48*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_6_torque_limit"
+    value="20"
+  />
 
-    <xacro:property name="joint_end_effector" value="end_effector_offset" />
-    <xacro:property name="joint_end_effector_type" value="fixed" />
-    <xacro:property name="joint_end_effector_axis_xyz" value="0 0 0" />
-    <xacro:property name="joint_end_effector_origin_xyz" value="0 0 -0.1600" />
-    <xacro:property name="joint_end_effector_origin_rpy" value="${J_PI} 0 ${J_PI/2}" />
+  <xacro:property
+    name="joint_end_effector"
+    value="end_effector_offset"
+  />
+  <xacro:property
+    name="joint_end_effector_type"
+    value="fixed"
+  />
+  <xacro:property
+    name="joint_end_effector_axis_xyz"
+    value="0 0 0"
+  />
+  <xacro:property
+    name="joint_end_effector_origin_xyz"
+    value="0 0 -0.1600"
+  />
+  <xacro:property
+    name="joint_end_effector_origin_rpy"
+    value="${J_PI} 0 ${J_PI/2}"
+  />
 
+  <xacro:macro
+    name="j2n6s300"
+    params="base_parent prefix:=j2n6s300"
+  >
+    <xacro:gazebo_config robot_namespace="${prefix}"/>
 
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_base"
+      link_mesh="${link_base_mesh}"
+      mesh_no="${link_base_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_base"
+      type="${joint_base_type}"
+      parent="${base_parent}"
+      child="${prefix}_link_base"
+      joint_axis_xyz="${joint_base_axis_xyz}"
+      joint_origin_xyz="${joint_base_origin_xyz}"
+      joint_origin_rpy="${joint_base_origin_rpy}"
+      joint_lower_limit="0"
+      joint_upper_limit="0"
+      joint_velocity_limit="0"
+      joint_torque_limit="0"
+      fixed="true"
+    />
 
-    <xacro:macro name="j2n6s300" params="base_parent prefix:=j2n6s300">
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_1"
+      link_mesh="${link_1_mesh}"
+      use_ring_mesh="true"
+      mesh_no="${link_1_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_1"
+      type="${joint_1_type}"
+      parent="${prefix}_link_base"
+      child="${prefix}_link_1"
+      joint_axis_xyz="${joint_1_axis_xyz}"
+      joint_origin_xyz="${joint_1_origin_xyz}"
+      joint_origin_rpy="${joint_1_origin_rpy}"
+      joint_lower_limit="${joint_1_lower_limit}"
+      joint_upper_limit="${joint_1_upper_limit}"
+      joint_velocity_limit="${joint_1_velocity_limit}"
+      joint_torque_limit="${joint_1_torque_limit}"
+    />
 
-        <xacro:gazebo_config robot_namespace="${prefix}"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_2"
+      link_mesh="${link_2_mesh}"
+      use_ring_mesh="true"
+      mesh_no="${link_2_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_2"
+      type="${joint_2_type}"
+      parent="${prefix}_link_1"
+      child="${prefix}_link_2"
+      joint_axis_xyz="${joint_2_axis_xyz}"
+      joint_origin_xyz="${joint_2_origin_xyz}"
+      joint_origin_rpy="${joint_2_origin_rpy}"
+      joint_lower_limit="${joint_2_lower_limit}"
+      joint_upper_limit="${joint_2_upper_limit}"
+      joint_velocity_limit="${joint_2_velocity_limit}"
+      joint_torque_limit="${joint_2_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_base" link_mesh="${link_base_mesh}" mesh_no="${link_base_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_base" type="${joint_base_type}" parent="${base_parent}" child="${prefix}_link_base" joint_axis_xyz="${joint_base_axis_xyz}" joint_origin_xyz="${joint_base_origin_xyz}" joint_origin_rpy="${joint_base_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0" joint_velocity_limit="0" joint_torque_limit="0" fixed="true"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_3"
+      link_mesh="${link_3_mesh}"
+      use_ring_mesh="true"
+      mesh_no="${link_3_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_3"
+      type="${joint_3_type}"
+      parent="${prefix}_link_2"
+      child="${prefix}_link_3"
+      joint_axis_xyz="${joint_3_axis_xyz}"
+      joint_origin_xyz="${joint_3_origin_xyz}"
+      joint_origin_rpy="${joint_3_origin_rpy}"
+      joint_lower_limit="${joint_3_lower_limit}"
+      joint_upper_limit="${joint_3_upper_limit}"
+      joint_velocity_limit="${joint_3_velocity_limit}"
+      joint_torque_limit="${joint_3_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_1" link_mesh="${link_1_mesh}" use_ring_mesh="true" mesh_no="${link_1_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_1" type="${joint_1_type}" parent="${prefix}_link_base" child="${prefix}_link_1" joint_axis_xyz="${joint_1_axis_xyz}" joint_origin_xyz="${joint_1_origin_xyz}" joint_origin_rpy="${joint_1_origin_rpy}" joint_lower_limit="${joint_1_lower_limit}" joint_upper_limit="${joint_1_upper_limit}" joint_velocity_limit="${joint_1_velocity_limit}" joint_torque_limit="${joint_1_torque_limit}"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_4"
+      link_mesh="${link_4_mesh}"
+      use_ring_mesh="true"
+      ring_mesh="ring_small"
+      mesh_no="${link_4_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_4"
+      type="${joint_4_type}"
+      parent="${prefix}_link_3"
+      child="${prefix}_link_4"
+      joint_axis_xyz="${joint_4_axis_xyz}"
+      joint_origin_xyz="${joint_4_origin_xyz}"
+      joint_origin_rpy="${joint_4_origin_rpy}"
+      joint_lower_limit="${joint_4_lower_limit}"
+      joint_upper_limit="${joint_4_upper_limit}"
+      joint_velocity_limit="${joint_4_velocity_limit}"
+      joint_torque_limit="${joint_4_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_2" link_mesh="${link_2_mesh}" use_ring_mesh="true" mesh_no="${link_2_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_2" type="${joint_2_type}" parent="${prefix}_link_1" child="${prefix}_link_2" joint_axis_xyz="${joint_2_axis_xyz}" joint_origin_xyz="${joint_2_origin_xyz}" joint_origin_rpy="${joint_2_origin_rpy}" joint_lower_limit="${joint_2_lower_limit}" joint_upper_limit="${joint_2_upper_limit}" joint_velocity_limit="${joint_2_velocity_limit}" joint_torque_limit="${joint_2_torque_limit}"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_5"
+      link_mesh="${link_5_mesh}"
+      use_ring_mesh="true"
+      ring_mesh="ring_small"
+      mesh_no="${link_5_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_5"
+      type="${joint_5_type}"
+      parent="${prefix}_link_4"
+      child="${prefix}_link_5"
+      joint_axis_xyz="${joint_5_axis_xyz}"
+      joint_origin_xyz="${joint_5_origin_xyz}"
+      joint_origin_rpy="${joint_5_origin_rpy}"
+      joint_lower_limit="${joint_5_lower_limit}"
+      joint_upper_limit="${joint_5_upper_limit}"
+      joint_velocity_limit="${joint_5_velocity_limit}"
+      joint_torque_limit="${joint_5_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_3" link_mesh="${link_3_mesh}" use_ring_mesh="true" mesh_no="${link_3_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_3" type="${joint_3_type}" parent="${prefix}_link_2" child="${prefix}_link_3" joint_axis_xyz="${joint_3_axis_xyz}" joint_origin_xyz="${joint_3_origin_xyz}" joint_origin_rpy="${joint_3_origin_rpy}" joint_lower_limit="${joint_3_lower_limit}" joint_upper_limit="${joint_3_upper_limit}" joint_velocity_limit="${joint_3_velocity_limit}" joint_torque_limit="${joint_3_torque_limit}"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_6"
+      link_mesh="${link_6_mesh}"
+      use_ring_mesh="true"
+      ring_mesh="ring_small"
+      mesh_no="${link_6_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_6"
+      type="${joint_6_type}"
+      parent="${prefix}_link_5"
+      child="${prefix}_link_6"
+      joint_axis_xyz="${joint_6_axis_xyz}"
+      joint_origin_xyz="${joint_6_origin_xyz}"
+      joint_origin_rpy="${joint_6_origin_rpy}"
+      joint_lower_limit="${joint_6_lower_limit}"
+      joint_upper_limit="${joint_6_upper_limit}"
+      joint_velocity_limit="${joint_6_velocity_limit}"
+      joint_torque_limit="${joint_6_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_4" link_mesh="${link_4_mesh}" use_ring_mesh="true" ring_mesh="ring_small" mesh_no="${link_4_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_4" type="${joint_4_type}" parent="${prefix}_link_3" child="${prefix}_link_4" joint_axis_xyz="${joint_4_axis_xyz}" joint_origin_xyz="${joint_4_origin_xyz}" joint_origin_rpy="${joint_4_origin_rpy}" joint_lower_limit="${joint_4_lower_limit}" joint_upper_limit="${joint_4_upper_limit}" joint_velocity_limit="${joint_4_velocity_limit}" joint_torque_limit="${joint_4_torque_limit}"/>
+    <xacro:kinova_virtual_link link_name="${prefix}_end_effector"/>
+    <xacro:kinova_virtual_joint
+      joint_name="${prefix}_joint_end_effector"
+      type="${joint_end_effector_type}"
+      parent="${prefix}_link_6"
+      child="${prefix}_end_effector"
+      joint_axis_xyz="${joint_end_effector_axis_xyz}"
+      joint_origin_xyz="${joint_end_effector_origin_xyz}"
+      joint_origin_rpy="${joint_end_effector_origin_rpy}"
+      joint_lower_limit="0"
+      joint_upper_limit="0"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_5" link_mesh="${link_5_mesh}" use_ring_mesh="true" ring_mesh="ring_small" mesh_no="${link_5_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_5" type="${joint_5_type}" parent="${prefix}_link_4" child="${prefix}_link_5" joint_axis_xyz="${joint_5_axis_xyz}" joint_origin_xyz="${joint_5_origin_xyz}" joint_origin_rpy="${joint_5_origin_rpy}" joint_lower_limit="${joint_5_lower_limit}" joint_upper_limit="${joint_5_upper_limit}" joint_velocity_limit="${joint_5_velocity_limit}" joint_torque_limit="${joint_5_torque_limit}"/>
-
-        <xacro:kinova_armlink link_name="${prefix}_link_6" link_mesh="${link_6_mesh}" use_ring_mesh="true" ring_mesh="ring_small" mesh_no="${link_6_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_6" type="${joint_6_type}" parent="${prefix}_link_5" child="${prefix}_link_6" joint_axis_xyz="${joint_6_axis_xyz}" joint_origin_xyz="${joint_6_origin_xyz}" joint_origin_rpy="${joint_6_origin_rpy}" joint_lower_limit="${joint_6_lower_limit}" joint_upper_limit="${joint_6_upper_limit}" joint_velocity_limit="${joint_6_velocity_limit}" joint_torque_limit="${joint_6_torque_limit}"/>
-
-
-        <xacro:kinova_virtual_link link_name="${prefix}_end_effector"/>
-        <xacro:kinova_virtual_joint joint_name="${prefix}_joint_end_effector" type="${joint_end_effector_type}" parent="${prefix}_link_6" child="${prefix}_end_effector" joint_axis_xyz="${joint_end_effector_axis_xyz}" joint_origin_xyz="${joint_end_effector_origin_xyz}" joint_origin_rpy="${joint_end_effector_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0"/>
-
-    <xacro:kinova_3fingers link_hand="${prefix}_link_6" prefix="${prefix}_"/>
-    </xacro:macro>
-
-
+    <xacro:kinova_3fingers
+      link_hand="${prefix}_link_6"
+      prefix="${prefix}_"
+    />
+  </xacro:macro>
 </root>

--- a/ada_description/urdf/j2n6s300_standalone.xacro
+++ b/ada_description/urdf/j2n6s300_standalone.xacro
@@ -1,22 +1,21 @@
 <?xml version="1.0"?>
 <!-- j2n6s300 refers to jaco v2 6DOF non-spherical 3fingers -->
-
-
-<robot xmlns:xi="http://www.w3.org/2001/XInclude"
-	xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
-    xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
-	xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-	xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
-    xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
-    xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
-	xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-	xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
-	xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
-    xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
-    xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-	xmlns:xacro="http://www.ros.org/wiki/xacro" name="j2n6s300">
-
-
+<robot
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
+  xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
+  xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+  xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
+  xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
+  xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
+  xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+  xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+  xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
+  xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
+  xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
+  xmlns:xacro="http://www.ros.org/wiki/xacro"
+  name="j2n6s300"
+>
   <xacro:include filename="$(find ada_description)/urdf/j2n6s300.xacro"/>
 
   <link name="root"/>
@@ -24,14 +23,22 @@
   <!-- for gazebo -->
   <link name="world"/>
 
-  <joint name="connect_root_and_world" type="fixed">
-    <child link="root" />
-    <parent link="world" />
-    <origin xyz="0 0 0" rpy="0 0 0" />
+  <joint
+    name="connect_root_and_world"
+    type="fixed"
+  >
+    <child link="root"/>
+    <parent link="world"/>
+    <origin
+      xyz="0 0 0"
+      rpy="0 0 0"
+    />
   </joint>
 
-  <xacro:property name="robot_root" value="root" />
+  <xacro:property
+    name="robot_root"
+    value="root"
+  />
 
-  <xacro:j2n6s300  base_parent="${robot_root}"/>
-
+  <xacro:j2n6s300 base_parent="${robot_root}"/>
 </robot>

--- a/ada_description/urdf/j2n7s300.xacro
+++ b/ada_description/urdf/j2n7s300.xacro
@@ -1,173 +1,586 @@
 <?xml version="1.0"?>
 <!-- j2_n7 refers to jaco v2 7DOF non-spherical -->
+<root
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
+  xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
+  xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+  xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
+  xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
+  xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
+  xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+  xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+  xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
+  xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
+  xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
+  xmlns:xacro="http://www.ros.org/wiki/xacro"
+>
+  <xacro:include filename="$(find ada_description)/urdf/kinova_common.xacro"/>
+  <xacro:include filename="$(find ada_description)/urdf/kinova_finger_set.xacro"/>
 
+  <!-- Import all Gazebo-customization elements -->
+  <xacro:include filename="$(find ada_description)/urdf/kinova.gazebo"/>
 
-<root xmlns:xi="http://www.w3.org/2001/XInclude"
-    xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
-    xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
-    xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-    xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
-    xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
-    xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
-    xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-    xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
-    xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
-    xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
-    xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-    xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:property
+    name="link_base_mesh"
+    value="base"
+  />
+  <xacro:property
+    name="link_1_mesh"
+    value="shoulder"
+  />
+  <xacro:property
+    name="link_2_mesh"
+    value="arm_half_1"
+  />
+  <xacro:property
+    name="link_3_mesh"
+    value="arm_half_2"
+  />
+  <xacro:property
+    name="link_4_mesh"
+    value="forearm"
+  />
+  <xacro:property
+    name="link_5_mesh"
+    value="wrist"
+  />
+  <xacro:property
+    name="link_6_mesh"
+    value="wrist"
+  />
+  <xacro:property
+    name="link_7_mesh"
+    value="hand_3finger"
+  />
 
-    <xacro:include filename="$(find ada_description)/urdf/kinova_common.xacro" />
-    <xacro:include filename="$(find ada_description)/urdf/kinova_finger_set.xacro" />
-
-    <!-- Import all Gazebo-customization elements -->
-    <xacro:include filename="$(find ada_description)/urdf/kinova.gazebo" />
-
-    <xacro:property name="link_base_mesh" value="base" />
-    <xacro:property name="link_1_mesh" value="shoulder" />
-    <xacro:property name="link_2_mesh" value="arm_half_1" />
-    <xacro:property name="link_3_mesh" value="arm_half_2" />
-    <xacro:property name="link_4_mesh" value="forearm" />
-    <xacro:property name="link_5_mesh" value="wrist" />
-    <xacro:property name="link_6_mesh" value="wrist" />
-    <xacro:property name="link_7_mesh" value="hand_3finger" />
-
-    <!--Used for conditional arguments for setting inertial parameters
+  <!--Used for conditional arguments for setting inertial parameters
         base 0, shoulder 1, arm 2, forearm 3, wrist 4, arm_mico 5,
         arm_half1 (7dof)	6, arm_half2 (7dof) 7, wrist_spherical_1  8, wrist_spherical_2  9
         fore_arm_mico 10,
         hand 3 finger 55, hand_2finger 56, finger_proximal 57, finger_distal 58
     -->
-    <xacro:property name="link_base_mesh_no" value="0" />
-    <xacro:property name="link_1_mesh_no" value="1" />
-    <xacro:property name="link_2_mesh_no" value="6" />
-    <xacro:property name="link_3_mesh_no" value="7" />
-    <xacro:property name="link_4_mesh_no" value="3" />
-    <xacro:property name="link_5_mesh_no" value="4" />
-    <xacro:property name="link_6_mesh_no" value="4" />
-    <xacro:property name="link_7_mesh_no" value="55" />
+  <xacro:property
+    name="link_base_mesh_no"
+    value="0"
+  />
+  <xacro:property
+    name="link_1_mesh_no"
+    value="1"
+  />
+  <xacro:property
+    name="link_2_mesh_no"
+    value="6"
+  />
+  <xacro:property
+    name="link_3_mesh_no"
+    value="7"
+  />
+  <xacro:property
+    name="link_4_mesh_no"
+    value="3"
+  />
+  <xacro:property
+    name="link_5_mesh_no"
+    value="4"
+  />
+  <xacro:property
+    name="link_6_mesh_no"
+    value="4"
+  />
+  <xacro:property
+    name="link_7_mesh_no"
+    value="55"
+  />
 
-    <xacro:property name="joint_base" value="joint_base" />
-    <xacro:property name="joint_base_type" value="fixed" />
-    <xacro:property name="joint_base_axis_xyz" value="0 0 0" />
-    <xacro:property name="joint_base_origin_xyz" value="0 0 0" />
-    <xacro:property name="joint_base_origin_rpy" value="0 0 0" />
+  <xacro:property
+    name="joint_base"
+    value="joint_base"
+  />
+  <xacro:property
+    name="joint_base_type"
+    value="fixed"
+  />
+  <xacro:property
+    name="joint_base_axis_xyz"
+    value="0 0 0"
+  />
+  <xacro:property
+    name="joint_base_origin_xyz"
+    value="0 0 0"
+  />
+  <xacro:property
+    name="joint_base_origin_rpy"
+    value="0 0 0"
+  />
 
-    <xacro:property name="joint_1" value="joint_1" />
-    <xacro:property name="joint_1_type" value="continuous" />
-    <xacro:property name="joint_1_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_1_origin_xyz" value="0 0 0.15675" />
-    <xacro:property name="joint_1_origin_rpy" value="0 ${J_PI} 0" />
-    <xacro:property name="joint_1_lower_limit" value="${-2*J_PI}" />
-    <xacro:property name="joint_1_upper_limit" value="${2*J_PI}" />
-    <xacro:property name="joint_1_velocity_limit" value="${36*J_PI/180}" />
-    <xacro:property name="joint_1_torque_limit" value="40" />
+  <xacro:property
+    name="joint_1"
+    value="joint_1"
+  />
+  <xacro:property
+    name="joint_1_type"
+    value="continuous"
+  />
+  <xacro:property
+    name="joint_1_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_1_origin_xyz"
+    value="0 0 0.15675"
+  />
+  <xacro:property
+    name="joint_1_origin_rpy"
+    value="0 ${J_PI} 0"
+  />
+  <xacro:property
+    name="joint_1_lower_limit"
+    value="${-2*J_PI}"
+  />
+  <xacro:property
+    name="joint_1_upper_limit"
+    value="${2*J_PI}"
+  />
+  <xacro:property
+    name="joint_1_velocity_limit"
+    value="${36*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_1_torque_limit"
+    value="40"
+  />
 
-    <xacro:property name="joint_2" value="joint_2" />
-    <xacro:property name="joint_2_type" value="revolute" />
-    <xacro:property name="joint_2_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_2_origin_xyz" value="0 0.0016 -0.11875" />
-    <xacro:property name="joint_2_origin_rpy" value="-${J_PI/2} 0 ${J_PI}" />
-    <xacro:property name="joint_2_lower_limit" value="${30/180*J_PI}" />
-    <xacro:property name="joint_2_upper_limit" value="${330/180*J_PI}" />
-    <xacro:property name="joint_2_velocity_limit" value="${36*J_PI/180}" />
-    <xacro:property name="joint_2_torque_limit" value="80" />
+  <xacro:property
+    name="joint_2"
+    value="joint_2"
+  />
+  <xacro:property
+    name="joint_2_type"
+    value="revolute"
+  />
+  <xacro:property
+    name="joint_2_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_2_origin_xyz"
+    value="0 0.0016 -0.11875"
+  />
+  <xacro:property
+    name="joint_2_origin_rpy"
+    value="-${J_PI/2} 0 ${J_PI}"
+  />
+  <xacro:property
+    name="joint_2_lower_limit"
+    value="${30/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_2_upper_limit"
+    value="${330/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_2_velocity_limit"
+    value="${36*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_2_torque_limit"
+    value="80"
+  />
 
-    <xacro:property name="joint_3" value="joint_3" />
-    <xacro:property name="joint_3_type" value="continuous" />
-    <xacro:property name="joint_3_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_3_origin_xyz" value="0 -0.205 0" />
-    <xacro:property name="joint_3_origin_rpy" value="${J_PI/2} 0 ${J_PI}" />
-    <xacro:property name="joint_3_lower_limit" value="${-5*J_PI/4}" />
-    <xacro:property name="joint_3_upper_limit" value="${1*J_PI/4}" />
-    <xacro:property name="joint_3_velocity_limit" value="${36*J_PI/180}" />
-    <xacro:property name="joint_3_torque_limit" value="40" />
+  <xacro:property
+    name="joint_3"
+    value="joint_3"
+  />
+  <xacro:property
+    name="joint_3_type"
+    value="continuous"
+  />
+  <xacro:property
+    name="joint_3_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_3_origin_xyz"
+    value="0 -0.205 0"
+  />
+  <xacro:property
+    name="joint_3_origin_rpy"
+    value="${J_PI/2} 0 ${J_PI}"
+  />
+  <xacro:property
+    name="joint_3_lower_limit"
+    value="${-5*J_PI/4}"
+  />
+  <xacro:property
+    name="joint_3_upper_limit"
+    value="${1*J_PI/4}"
+  />
+  <xacro:property
+    name="joint_3_velocity_limit"
+    value="${36*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_3_torque_limit"
+    value="40"
+  />
 
-    <xacro:property name="joint_4" value="joint_4" />
-    <xacro:property name="joint_4_type" value="revolute" />
-    <xacro:property name="joint_4_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_4_origin_xyz" value="0 0 -0.205" />
-    <xacro:property name="joint_4_origin_rpy" value="${J_PI/2} 0 ${J_PI}" />
-    <xacro:property name="joint_4_lower_limit" value="${30/180*J_PI}" />
-    <xacro:property name="joint_4_upper_limit" value="${330/180*J_PI}" />
-    <xacro:property name="joint_4_velocity_limit" value="${36*J_PI/180}" />
-    <xacro:property name="joint_4_torque_limit" value="40" />
+  <xacro:property
+    name="joint_4"
+    value="joint_4"
+  />
+  <xacro:property
+    name="joint_4_type"
+    value="revolute"
+  />
+  <xacro:property
+    name="joint_4_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_4_origin_xyz"
+    value="0 0 -0.205"
+  />
+  <xacro:property
+    name="joint_4_origin_rpy"
+    value="${J_PI/2} 0 ${J_PI}"
+  />
+  <xacro:property
+    name="joint_4_lower_limit"
+    value="${30/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_4_upper_limit"
+    value="${330/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_4_velocity_limit"
+    value="${36*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_4_torque_limit"
+    value="40"
+  />
 
+  <xacro:property
+    name="joint_5"
+    value="joint_5"
+  />
+  <xacro:property
+    name="joint_5_type"
+    value="continuous"
+  />
+  <xacro:property
+    name="joint_5_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_5_origin_xyz"
+    value="0 0.2073 -0.0114"
+  />
+  <xacro:property
+    name="joint_5_origin_rpy"
+    value="${-J_PI/2} 0 ${J_PI}"
+  />
+  <xacro:property
+    name="joint_5_lower_limit"
+    value="${-2*J_PI}"
+  />
+  <xacro:property
+    name="joint_5_upper_limit"
+    value="${2*J_PI}"
+  />
+  <xacro:property
+    name="joint_5_velocity_limit"
+    value="${48*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_5_torque_limit"
+    value="20"
+  />
 
-    <xacro:property name="joint_5" value="joint_5" />
-    <xacro:property name="joint_5_type" value="continuous" />
-    <xacro:property name="joint_5_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_5_origin_xyz" value="0 0.2073 -0.0114" />
-    <xacro:property name="joint_5_origin_rpy" value="${-J_PI/2} 0 ${J_PI}" />
-    <xacro:property name="joint_5_lower_limit" value="${-2*J_PI}" />
-    <xacro:property name="joint_5_upper_limit" value="${2*J_PI}" />
-    <xacro:property name="joint_5_velocity_limit" value="${48*J_PI/180}" />
-    <xacro:property name="joint_5_torque_limit" value="20" />
+  <xacro:property
+    name="joint_6"
+    value="joint_6"
+  />
+  <xacro:property
+    name="joint_6_type"
+    value="continuous"
+  />
+  <xacro:property
+    name="joint_6_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_6_origin_xyz"
+    value="0 -0.03703 -0.06414"
+  />
+  <xacro:property
+    name="joint_6_origin_rpy"
+    value="${J_PI/3} 0 ${J_PI}"
+  />
+  <!-- If gripper inverted, use this line instead -->
+  <!-- <xacro:property name="joint_6_origin_rpy" value="$${-J_PI/3} 0 0" /> -->
+  <xacro:property
+    name="joint_6_lower_limit"
+    value="${-2*J_PI}"
+  />
+  <xacro:property
+    name="joint_6_upper_limit"
+    value="${2*J_PI}"
+  />
+  <xacro:property
+    name="joint_6_velocity_limit"
+    value="${48*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_6_torque_limit"
+    value="20"
+  />
 
-    <xacro:property name="joint_6" value="joint_6" />
-    <xacro:property name="joint_6_type" value="continuous" />
-    <xacro:property name="joint_6_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_6_origin_xyz" value="0 -0.03703 -0.06414" />
-    <xacro:property name="joint_6_origin_rpy" value="${J_PI/3} 0 ${J_PI}" />
-    <!-- If gripper inverted, use this line instead -->
-    <!-- <xacro:property name="joint_6_origin_rpy" value="$${-J_PI/3} 0 0" /> -->
-    <xacro:property name="joint_6_lower_limit" value="${-2*J_PI}" />
-    <xacro:property name="joint_6_upper_limit" value="${2*J_PI}" />
-    <xacro:property name="joint_6_velocity_limit" value="${48*J_PI/180}" />
-    <xacro:property name="joint_6_torque_limit" value="20" />
+  <xacro:property
+    name="joint_7"
+    value="joint_7"
+  />
+  <xacro:property
+    name="joint_7_type"
+    value="continuous"
+  />
+  <xacro:property
+    name="joint_7_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_7_origin_xyz"
+    value="0 -0.03703 -0.06414"
+  />
+  <xacro:property
+    name="joint_7_origin_rpy"
+    value="${J_PI/3} 0 ${J_PI}"
+  />
+  <xacro:property
+    name="joint_7_lower_limit"
+    value="${-2*J_PI}"
+  />
+  <xacro:property
+    name="joint_7_upper_limit"
+    value="${2*J_PI}"
+  />
+  <xacro:property
+    name="joint_7_velocity_limit"
+    value="${48*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_7_torque_limit"
+    value="20"
+  />
 
-    <xacro:property name="joint_7" value="joint_7" />
-    <xacro:property name="joint_7_type" value="continuous" />
-    <xacro:property name="joint_7_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_7_origin_xyz" value="0 -0.03703 -0.06414" />
-    <xacro:property name="joint_7_origin_rpy" value="${J_PI/3} 0 ${J_PI}" />
-    <xacro:property name="joint_7_lower_limit" value="${-2*J_PI}" />
-    <xacro:property name="joint_7_upper_limit" value="${2*J_PI}" />
-    <xacro:property name="joint_7_velocity_limit" value="${48*J_PI/180}" />
-    <xacro:property name="joint_7_torque_limit" value="20" />
+  <xacro:property
+    name="joint_end_effector"
+    value="end_effector_offset"
+  />
+  <xacro:property
+    name="joint_end_effector_type"
+    value="fixed"
+  />
+  <xacro:property
+    name="joint_end_effector_axis_xyz"
+    value="0 0 0"
+  />
+  <xacro:property
+    name="joint_end_effector_origin_xyz"
+    value="0 0 -0.1600"
+  />
+  <xacro:property
+    name="joint_end_effector_origin_rpy"
+    value="${J_PI} 0 ${J_PI/2}"
+  />
 
-    <xacro:property name="joint_end_effector" value="end_effector_offset" />
-    <xacro:property name="joint_end_effector_type" value="fixed" />
-    <xacro:property name="joint_end_effector_axis_xyz" value="0 0 0" />
-    <xacro:property name="joint_end_effector_origin_xyz" value="0 0 -0.1600" />
-    <xacro:property name="joint_end_effector_origin_rpy" value="${J_PI} 0 ${J_PI/2}" />
+  <xacro:macro
+    name="j2n7s300"
+    params="base_parent prefix:=j2n7s300"
+  >
+    <xacro:gazebo_config robot_namespace="${prefix}"/>
 
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_base"
+      link_mesh="${link_base_mesh}"
+      mesh_no="${link_base_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_base"
+      type="${joint_base_type}"
+      parent="${base_parent}"
+      child="${prefix}_link_base"
+      joint_axis_xyz="${joint_base_axis_xyz}"
+      joint_origin_xyz="${joint_base_origin_xyz}"
+      joint_origin_rpy="${joint_base_origin_rpy}"
+      joint_lower_limit="0"
+      joint_upper_limit="0"
+      joint_velocity_limit="0"
+      joint_torque_limit="0"
+      fixed="true"
+    />
 
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_1"
+      link_mesh="${link_1_mesh}"
+      use_ring_mesh="true"
+      mesh_no="${link_1_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_1"
+      type="${joint_1_type}"
+      parent="${prefix}_link_base"
+      child="${prefix}_link_1"
+      joint_axis_xyz="${joint_1_axis_xyz}"
+      joint_origin_xyz="${joint_1_origin_xyz}"
+      joint_origin_rpy="${joint_1_origin_rpy}"
+      joint_lower_limit="${joint_1_lower_limit}"
+      joint_upper_limit="${joint_1_upper_limit}"
+      joint_velocity_limit="${joint_1_velocity_limit}"
+      joint_torque_limit="${joint_1_torque_limit}"
+    />
 
-    <xacro:macro name="j2n7s300" params="base_parent prefix:=j2n7s300">
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_2"
+      link_mesh="${link_2_mesh}"
+      use_ring_mesh="true"
+      mesh_no="${link_2_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_2"
+      type="${joint_2_type}"
+      parent="${prefix}_link_1"
+      child="${prefix}_link_2"
+      joint_axis_xyz="${joint_2_axis_xyz}"
+      joint_origin_xyz="${joint_2_origin_xyz}"
+      joint_origin_rpy="${joint_2_origin_rpy}"
+      joint_lower_limit="${joint_2_lower_limit}"
+      joint_upper_limit="${joint_2_upper_limit}"
+      joint_velocity_limit="${joint_2_velocity_limit}"
+      joint_torque_limit="${joint_2_torque_limit}"
+    />
 
-        <xacro:gazebo_config robot_namespace="${prefix}"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_3"
+      link_mesh="${link_3_mesh}"
+      use_ring_mesh="true"
+      mesh_no="${link_3_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_3"
+      type="${joint_3_type}"
+      parent="${prefix}_link_2"
+      child="${prefix}_link_3"
+      joint_axis_xyz="${joint_3_axis_xyz}"
+      joint_origin_xyz="${joint_3_origin_xyz}"
+      joint_origin_rpy="${joint_3_origin_rpy}"
+      joint_lower_limit="${joint_3_lower_limit}"
+      joint_upper_limit="${joint_3_upper_limit}"
+      joint_velocity_limit="${joint_3_velocity_limit}"
+      joint_torque_limit="${joint_3_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_base" link_mesh="${link_base_mesh}" mesh_no="${link_base_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_base" type="${joint_base_type}" parent="${base_parent}" child="${prefix}_link_base" joint_axis_xyz="${joint_base_axis_xyz}" joint_origin_xyz="${joint_base_origin_xyz}" joint_origin_rpy="${joint_base_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0" joint_velocity_limit="0" joint_torque_limit="0" fixed="true"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_4"
+      link_mesh="${link_4_mesh}"
+      use_ring_mesh="true"
+      mesh_no="${link_4_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_4"
+      type="${joint_4_type}"
+      parent="${prefix}_link_3"
+      child="${prefix}_link_4"
+      joint_axis_xyz="${joint_4_axis_xyz}"
+      joint_origin_xyz="${joint_4_origin_xyz}"
+      joint_origin_rpy="${joint_4_origin_rpy}"
+      joint_lower_limit="${joint_4_lower_limit}"
+      joint_upper_limit="${joint_4_upper_limit}"
+      joint_velocity_limit="${joint_4_velocity_limit}"
+      joint_torque_limit="${joint_4_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_1" link_mesh="${link_1_mesh}" use_ring_mesh="true" mesh_no="${link_1_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_1" type="${joint_1_type}" parent="${prefix}_link_base" child="${prefix}_link_1" joint_axis_xyz="${joint_1_axis_xyz}" joint_origin_xyz="${joint_1_origin_xyz}" joint_origin_rpy="${joint_1_origin_rpy}" joint_lower_limit="${joint_1_lower_limit}" joint_upper_limit="${joint_1_upper_limit}" joint_velocity_limit="${joint_1_velocity_limit}" joint_torque_limit="${joint_1_torque_limit}"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_5"
+      link_mesh="${link_5_mesh}"
+      use_ring_mesh="true"
+      ring_mesh="ring_small"
+      mesh_no="${link_5_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_5"
+      type="${joint_5_type}"
+      parent="${prefix}_link_4"
+      child="${prefix}_link_5"
+      joint_axis_xyz="${joint_5_axis_xyz}"
+      joint_origin_xyz="${joint_5_origin_xyz}"
+      joint_origin_rpy="${joint_5_origin_rpy}"
+      joint_lower_limit="${joint_5_lower_limit}"
+      joint_upper_limit="${joint_5_upper_limit}"
+      joint_velocity_limit="${joint_5_velocity_limit}"
+      joint_torque_limit="${joint_5_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_2" link_mesh="${link_2_mesh}" use_ring_mesh="true" mesh_no="${link_2_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_2" type="${joint_2_type}" parent="${prefix}_link_1" child="${prefix}_link_2" joint_axis_xyz="${joint_2_axis_xyz}" joint_origin_xyz="${joint_2_origin_xyz}" joint_origin_rpy="${joint_2_origin_rpy}" joint_lower_limit="${joint_2_lower_limit}" joint_upper_limit="${joint_2_upper_limit}" joint_velocity_limit="${joint_2_velocity_limit}" joint_torque_limit="${joint_2_torque_limit}"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_6"
+      link_mesh="${link_6_mesh}"
+      use_ring_mesh="true"
+      ring_mesh="ring_small"
+      mesh_no="${link_6_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_6"
+      type="${joint_6_type}"
+      parent="${prefix}_link_5"
+      child="${prefix}_link_6"
+      joint_axis_xyz="${joint_6_axis_xyz}"
+      joint_origin_xyz="${joint_6_origin_xyz}"
+      joint_origin_rpy="${joint_6_origin_rpy}"
+      joint_lower_limit="${joint_6_lower_limit}"
+      joint_upper_limit="${joint_6_upper_limit}"
+      joint_velocity_limit="${joint_6_velocity_limit}"
+      joint_torque_limit="${joint_6_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_3" link_mesh="${link_3_mesh}" use_ring_mesh="true" mesh_no="${link_3_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_3" type="${joint_3_type}" parent="${prefix}_link_2" child="${prefix}_link_3" joint_axis_xyz="${joint_3_axis_xyz}" joint_origin_xyz="${joint_3_origin_xyz}" joint_origin_rpy="${joint_3_origin_rpy}" joint_lower_limit="${joint_3_lower_limit}" joint_upper_limit="${joint_3_upper_limit}" joint_velocity_limit="${joint_3_velocity_limit}" joint_torque_limit="${joint_3_torque_limit}"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_7"
+      link_mesh="${link_7_mesh}"
+      use_ring_mesh="true"
+      ring_mesh="ring_small"
+      mesh_no="${link_7_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_7"
+      type="${joint_7_type}"
+      parent="${prefix}_link_6"
+      child="${prefix}_link_7"
+      joint_axis_xyz="${joint_7_axis_xyz}"
+      joint_origin_xyz="${joint_7_origin_xyz}"
+      joint_origin_rpy="${joint_7_origin_rpy}"
+      joint_lower_limit="${joint_7_lower_limit}"
+      joint_upper_limit="${joint_7_upper_limit}"
+      joint_velocity_limit="${joint_7_velocity_limit}"
+      joint_torque_limit="${joint_7_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_4" link_mesh="${link_4_mesh}" use_ring_mesh="true" mesh_no="${link_4_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_4" type="${joint_4_type}" parent="${prefix}_link_3" child="${prefix}_link_4" joint_axis_xyz="${joint_4_axis_xyz}" joint_origin_xyz="${joint_4_origin_xyz}" joint_origin_rpy="${joint_4_origin_rpy}" joint_lower_limit="${joint_4_lower_limit}" joint_upper_limit="${joint_4_upper_limit}" joint_velocity_limit="${joint_4_velocity_limit}" joint_torque_limit="${joint_4_torque_limit}"/>
+    <xacro:kinova_virtual_link link_name="${prefix}_end_effector"/>
+    <xacro:kinova_virtual_joint
+      joint_name="${prefix}_joint_end_effector"
+      type="${joint_end_effector_type}"
+      parent="${prefix}_link_7"
+      child="${prefix}_end_effector"
+      joint_axis_xyz="${joint_end_effector_axis_xyz}"
+      joint_origin_xyz="${joint_end_effector_origin_xyz}"
+      joint_origin_rpy="${joint_end_effector_origin_rpy}"
+      joint_lower_limit="0"
+      joint_upper_limit="0"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_5" link_mesh="${link_5_mesh}" use_ring_mesh="true" ring_mesh="ring_small" mesh_no="${link_5_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_5" type="${joint_5_type}" parent="${prefix}_link_4" child="${prefix}_link_5" joint_axis_xyz="${joint_5_axis_xyz}" joint_origin_xyz="${joint_5_origin_xyz}" joint_origin_rpy="${joint_5_origin_rpy}" joint_lower_limit="${joint_5_lower_limit}" joint_upper_limit="${joint_5_upper_limit}" joint_velocity_limit="${joint_5_velocity_limit}" joint_torque_limit="${joint_5_torque_limit}"/>
-
-        <xacro:kinova_armlink link_name="${prefix}_link_6" link_mesh="${link_6_mesh}" use_ring_mesh="true" ring_mesh="ring_small" mesh_no="${link_6_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_6" type="${joint_6_type}" parent="${prefix}_link_5" child="${prefix}_link_6" joint_axis_xyz="${joint_6_axis_xyz}" joint_origin_xyz="${joint_6_origin_xyz}" joint_origin_rpy="${joint_6_origin_rpy}" joint_lower_limit="${joint_6_lower_limit}" joint_upper_limit="${joint_6_upper_limit}" joint_velocity_limit="${joint_6_velocity_limit}" joint_torque_limit="${joint_6_torque_limit}"/>
-
-        <xacro:kinova_armlink link_name="${prefix}_link_7" link_mesh="${link_7_mesh}" use_ring_mesh="true" ring_mesh="ring_small" mesh_no="${link_7_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_7" type="${joint_7_type}" parent="${prefix}_link_6" child="${prefix}_link_7" joint_axis_xyz="${joint_7_axis_xyz}" joint_origin_xyz="${joint_7_origin_xyz}" joint_origin_rpy="${joint_7_origin_rpy}" joint_lower_limit="${joint_7_lower_limit}" joint_upper_limit="${joint_7_upper_limit}" joint_velocity_limit="${joint_7_velocity_limit}" joint_torque_limit="${joint_7_torque_limit}"/>
-
-        <xacro:kinova_virtual_link link_name="${prefix}_end_effector"/>
-        <xacro:kinova_virtual_joint joint_name="${prefix}_joint_end_effector" type="${joint_end_effector_type}" parent="${prefix}_link_7" child="${prefix}_end_effector" joint_axis_xyz="${joint_end_effector_axis_xyz}" joint_origin_xyz="${joint_end_effector_origin_xyz}" joint_origin_rpy="${joint_end_effector_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0"/>
-
-        <xacro:kinova_3fingers link_hand="${prefix}_link_7" prefix="${prefix}_"/>
-
-    </xacro:macro>
-
-
-
+    <xacro:kinova_3fingers
+      link_hand="${prefix}_link_7"
+      prefix="${prefix}_"
+    />
+  </xacro:macro>
 </root>

--- a/ada_description/urdf/j2n7s300_standalone.xacro
+++ b/ada_description/urdf/j2n7s300_standalone.xacro
@@ -1,22 +1,21 @@
 <?xml version="1.0"?>
 <!-- j2n7s300 refers to jaco v2 7DOF non-spherical service 3fingers -->
-
-
-<robot xmlns:xi="http://www.w3.org/2001/XInclude"
-	xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
-    xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
-	xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-	xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
-    xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
-    xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
-	xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-	xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
-	xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
-    xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
-    xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-	xmlns:xacro="http://www.ros.org/wiki/xacro" name="j2n7s300">
-
-
+<robot
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
+  xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
+  xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+  xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
+  xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
+  xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
+  xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+  xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+  xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
+  xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
+  xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
+  xmlns:xacro="http://www.ros.org/wiki/xacro"
+  name="j2n7s300"
+>
   <xacro:include filename="$(find ada_description)/urdf/j2n7s300.xacro"/>
 
   <link name="root"/>
@@ -24,14 +23,22 @@
   <!-- for gazebo -->
   <link name="world"/>
 
-  <joint name="connect_root_and_world" type="fixed">
-    <child link="root" />
-    <parent link="world" />
-    <origin xyz="0 0 0" rpy="0 0 0" />
+  <joint
+    name="connect_root_and_world"
+    type="fixed"
+  >
+    <child link="root"/>
+    <parent link="world"/>
+    <origin
+      xyz="0 0 0"
+      rpy="0 0 0"
+    />
   </joint>
 
-  <xacro:property name="robot_root" value="root" />
+  <xacro:property
+    name="robot_root"
+    value="root"
+  />
 
-  <xacro:j2n7s300  base_parent="${robot_root}"/>
-
+  <xacro:j2n7s300 base_parent="${robot_root}"/>
 </robot>

--- a/ada_description/urdf/j2s6s200.xacro
+++ b/ada_description/urdf/j2s6s200.xacro
@@ -1,155 +1,519 @@
 <?xml version="1.0"?>
 <!-- j2_6s refers to jaco v2 6DOF spherical -->
+<root
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
+  xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
+  xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+  xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
+  xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
+  xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
+  xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+  xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+  xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
+  xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
+  xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
+  xmlns:xacro="http://www.ros.org/wiki/xacro"
+>
+  <xacro:include filename="$(find ada_description)/urdf/kinova_common.xacro"/>
+  <xacro:include filename="$(find ada_description)/urdf/kinova_finger_set.xacro"/>
 
+  <!-- Import all Gazebo-customization elements -->
+  <xacro:include filename="$(find ada_description)/urdf/kinova.gazebo"/>
 
-<root xmlns:xi="http://www.w3.org/2001/XInclude"
-    xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
-    xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
-    xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-    xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
-    xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
-    xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
-    xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-    xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
-    xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
-    xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
-    xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-    xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:property
+    name="link_base_mesh"
+    value="base"
+  />
+  <xacro:property
+    name="link_1_mesh"
+    value="shoulder"
+  />
+  <xacro:property
+    name="link_2_mesh"
+    value="arm"
+  />
+  <xacro:property
+    name="link_3_mesh"
+    value="forearm"
+  />
+  <xacro:property
+    name="link_4_mesh"
+    value="wrist_spherical_1"
+  />
+  <xacro:property
+    name="link_5_mesh"
+    value="wrist_spherical_2"
+  />
+  <xacro:property
+    name="link_6_mesh"
+    value="hand_2finger"
+  />
 
-    <xacro:include filename="$(find ada_description)/urdf/kinova_common.xacro" />
-    <xacro:include filename="$(find ada_description)/urdf/kinova_finger_set.xacro" />
-
-    <!-- Import all Gazebo-customization elements -->
-    <xacro:include filename="$(find ada_description)/urdf/kinova.gazebo" />
-
-    <xacro:property name="link_base_mesh" value="base" />
-    <xacro:property name="link_1_mesh" value="shoulder" />
-    <xacro:property name="link_2_mesh" value="arm" />
-    <xacro:property name="link_3_mesh" value="forearm" />
-    <xacro:property name="link_4_mesh" value="wrist_spherical_1" />
-    <xacro:property name="link_5_mesh" value="wrist_spherical_2" />
-    <xacro:property name="link_6_mesh" value="hand_2finger" />
-
-    <!--Used for conditional arguments for setting inertial parameters
+  <!--Used for conditional arguments for setting inertial parameters
         base 0, shoulder 1, arm 2, forearm 3, wrist 4, arm_mico 5,
         arm_half1 (7dof)	6, arm_half2 (7dof) 7, wrist_spherical_1  8, wrist_spherical_2  9
         fore_arm_mico 10,
         hand 3 finger 55, hand_2finger 56, finger_proximal 57, finger_distal 58
     -->
-    <xacro:property name="link_base_mesh_no" value="0" />
-    <xacro:property name="link_1_mesh_no" value="1" />
-    <xacro:property name="link_2_mesh_no" value="2" />
-    <xacro:property name="link_3_mesh_no" value="3" />
-    <xacro:property name="link_4_mesh_no" value="8" />
-    <xacro:property name="link_5_mesh_no" value="9" />
-    <xacro:property name="link_6_mesh_no" value="55" />
+  <xacro:property
+    name="link_base_mesh_no"
+    value="0"
+  />
+  <xacro:property
+    name="link_1_mesh_no"
+    value="1"
+  />
+  <xacro:property
+    name="link_2_mesh_no"
+    value="2"
+  />
+  <xacro:property
+    name="link_3_mesh_no"
+    value="3"
+  />
+  <xacro:property
+    name="link_4_mesh_no"
+    value="8"
+  />
+  <xacro:property
+    name="link_5_mesh_no"
+    value="9"
+  />
+  <xacro:property
+    name="link_6_mesh_no"
+    value="55"
+  />
 
-    <xacro:property name="joint_base" value="joint_base" />
-    <xacro:property name="joint_base_type" value="fixed" />
-    <xacro:property name="joint_base_axis_xyz" value="0 0 0" />
-    <xacro:property name="joint_base_origin_xyz" value="0 0 0" />
-    <xacro:property name="joint_base_origin_rpy" value="0 0 0" />
+  <xacro:property
+    name="joint_base"
+    value="joint_base"
+  />
+  <xacro:property
+    name="joint_base_type"
+    value="fixed"
+  />
+  <xacro:property
+    name="joint_base_axis_xyz"
+    value="0 0 0"
+  />
+  <xacro:property
+    name="joint_base_origin_xyz"
+    value="0 0 0"
+  />
+  <xacro:property
+    name="joint_base_origin_rpy"
+    value="0 0 0"
+  />
 
-    <xacro:property name="joint_1" value="joint_1" />
-    <xacro:property name="joint_1_type" value="continuous" />
-    <xacro:property name="joint_1_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_1_origin_xyz" value="0 0 0.15675" />
-    <xacro:property name="joint_1_origin_rpy" value="0 ${J_PI} 0" />
-    <xacro:property name="joint_1_lower_limit" value="${-2*J_PI}" />
-    <xacro:property name="joint_1_upper_limit" value="${2*J_PI}" />
-    <xacro:property name="joint_1_velocity_limit" value="${36*J_PI/180}" />
-    <xacro:property name="joint_1_torque_limit" value="40" />
+  <xacro:property
+    name="joint_1"
+    value="joint_1"
+  />
+  <xacro:property
+    name="joint_1_type"
+    value="continuous"
+  />
+  <xacro:property
+    name="joint_1_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_1_origin_xyz"
+    value="0 0 0.15675"
+  />
+  <xacro:property
+    name="joint_1_origin_rpy"
+    value="0 ${J_PI} 0"
+  />
+  <xacro:property
+    name="joint_1_lower_limit"
+    value="${-2*J_PI}"
+  />
+  <xacro:property
+    name="joint_1_upper_limit"
+    value="${2*J_PI}"
+  />
+  <xacro:property
+    name="joint_1_velocity_limit"
+    value="${36*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_1_torque_limit"
+    value="40"
+  />
 
-    <xacro:property name="joint_2" value="joint_2" />
-    <xacro:property name="joint_2_type" value="revolute" />
-    <xacro:property name="joint_2_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_2_origin_xyz" value="0 0.0016 -0.11875" />
-    <xacro:property name="joint_2_origin_rpy" value="${-J_PI/2} 0 ${J_PI}"/>
-    <xacro:property name="joint_2_lower_limit" value="${47/180*J_PI}" />
-    <xacro:property name="joint_2_upper_limit" value="${313/180*J_PI}" />
-    <xacro:property name="joint_2_velocity_limit" value="${36*J_PI/180}" />
-    <xacro:property name="joint_2_torque_limit" value="80" />
+  <xacro:property
+    name="joint_2"
+    value="joint_2"
+  />
+  <xacro:property
+    name="joint_2_type"
+    value="revolute"
+  />
+  <xacro:property
+    name="joint_2_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_2_origin_xyz"
+    value="0 0.0016 -0.11875"
+  />
+  <xacro:property
+    name="joint_2_origin_rpy"
+    value="${-J_PI/2} 0 ${J_PI}"
+  />
+  <xacro:property
+    name="joint_2_lower_limit"
+    value="${47/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_2_upper_limit"
+    value="${313/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_2_velocity_limit"
+    value="${36*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_2_torque_limit"
+    value="80"
+  />
 
-    <xacro:property name="joint_3" value="joint_3" />
-    <xacro:property name="joint_3_type" value="revolute" />
-    <xacro:property name="joint_3_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_3_origin_xyz" value="0 -0.410 0" />
-    <xacro:property name="joint_3_origin_rpy" value="0 ${J_PI} 0" />
-    <xacro:property name="joint_3_lower_limit" value="${19/180*J_PI}" />
-    <xacro:property name="joint_3_upper_limit" value="${341/180*J_PI}" />
-    <xacro:property name="joint_3_velocity_limit" value="${36*J_PI/180}" />
-    <xacro:property name="joint_3_torque_limit" value="40" />
+  <xacro:property
+    name="joint_3"
+    value="joint_3"
+  />
+  <xacro:property
+    name="joint_3_type"
+    value="revolute"
+  />
+  <xacro:property
+    name="joint_3_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_3_origin_xyz"
+    value="0 -0.410 0"
+  />
+  <xacro:property
+    name="joint_3_origin_rpy"
+    value="0 ${J_PI} 0"
+  />
+  <xacro:property
+    name="joint_3_lower_limit"
+    value="${19/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_3_upper_limit"
+    value="${341/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_3_velocity_limit"
+    value="${36*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_3_torque_limit"
+    value="40"
+  />
 
-    <xacro:property name="joint_4" value="joint_4" />
-    <xacro:property name="joint_4_type" value="continuous" />
-    <xacro:property name="joint_4_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_4_origin_xyz" value="0 0.2073 -0.0114" />
-    <xacro:property name="joint_4_origin_rpy" value="${-J_PI/2} 0 ${J_PI}" />
-    <xacro:property name="joint_4_lower_limit" value="${-2*J_PI}" />
-    <xacro:property name="joint_4_upper_limit" value="${2*J_PI}" />
-    <xacro:property name="joint_4_velocity_limit" value="${48*J_PI/180}" />
-    <xacro:property name="joint_4_torque_limit" value="20" />
+  <xacro:property
+    name="joint_4"
+    value="joint_4"
+  />
+  <xacro:property
+    name="joint_4_type"
+    value="continuous"
+  />
+  <xacro:property
+    name="joint_4_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_4_origin_xyz"
+    value="0 0.2073 -0.0114"
+  />
+  <xacro:property
+    name="joint_4_origin_rpy"
+    value="${-J_PI/2} 0 ${J_PI}"
+  />
+  <xacro:property
+    name="joint_4_lower_limit"
+    value="${-2*J_PI}"
+  />
+  <xacro:property
+    name="joint_4_upper_limit"
+    value="${2*J_PI}"
+  />
+  <xacro:property
+    name="joint_4_velocity_limit"
+    value="${48*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_4_torque_limit"
+    value="20"
+  />
 
-    <xacro:property name="joint_5" value="joint_5" />
-    <xacro:property name="joint_5_type" value="revolute" />
-    <xacro:property name="joint_5_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_5_origin_xyz" value="0 0 -0.10375" />
-    <xacro:property name="joint_5_origin_rpy" value="${J_PI/2} 0 ${J_PI}" />
-    <xacro:property name="joint_5_lower_limit" value="${30/180*J_PI}" />
-    <xacro:property name="joint_5_upper_limit" value="${330/180*J_PI}" />
-    <xacro:property name="joint_5_velocity_limit" value="${48*J_PI/180}" />
-    <xacro:property name="joint_5_torque_limit" value="20" />
+  <xacro:property
+    name="joint_5"
+    value="joint_5"
+  />
+  <xacro:property
+    name="joint_5_type"
+    value="revolute"
+  />
+  <xacro:property
+    name="joint_5_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_5_origin_xyz"
+    value="0 0 -0.10375"
+  />
+  <xacro:property
+    name="joint_5_origin_rpy"
+    value="${J_PI/2} 0 ${J_PI}"
+  />
+  <xacro:property
+    name="joint_5_lower_limit"
+    value="${30/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_5_upper_limit"
+    value="${330/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_5_velocity_limit"
+    value="${48*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_5_torque_limit"
+    value="20"
+  />
 
-    <xacro:property name="joint_6" value="joint_6" />
-    <xacro:property name="joint_6_type" value="continuous" />
-    <xacro:property name="joint_6_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_6_origin_xyz" value="0 0.10375 0" />
-    <xacro:property name="joint_6_origin_rpy" value="${-J_PI/2} 0 ${J_PI}" />
-    <xacro:property name="joint_6_lower_limit" value="${-2*J_PI}" />
-    <xacro:property name="joint_6_upper_limit" value="${2*J_PI}" />
-    <xacro:property name="joint_6_velocity_limit" value="${48*J_PI/180}" />
-    <xacro:property name="joint_6_torque_limit" value="20" />
+  <xacro:property
+    name="joint_6"
+    value="joint_6"
+  />
+  <xacro:property
+    name="joint_6_type"
+    value="continuous"
+  />
+  <xacro:property
+    name="joint_6_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_6_origin_xyz"
+    value="0 0.10375 0"
+  />
+  <xacro:property
+    name="joint_6_origin_rpy"
+    value="${-J_PI/2} 0 ${J_PI}"
+  />
+  <xacro:property
+    name="joint_6_lower_limit"
+    value="${-2*J_PI}"
+  />
+  <xacro:property
+    name="joint_6_upper_limit"
+    value="${2*J_PI}"
+  />
+  <xacro:property
+    name="joint_6_velocity_limit"
+    value="${48*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_6_torque_limit"
+    value="20"
+  />
 
-    <xacro:property name="joint_end_effector" value="end_effector_offset" />
-    <xacro:property name="joint_end_effector_type" value="fixed" />
-    <xacro:property name="joint_end_effector_axis_xyz" value="0 0 0" />
-    <xacro:property name="joint_end_effector_origin_xyz" value="0 0 -0.1600" />
-    <xacro:property name="joint_end_effector_origin_rpy" value="${J_PI} 0 ${J_PI/2}" />
+  <xacro:property
+    name="joint_end_effector"
+    value="end_effector_offset"
+  />
+  <xacro:property
+    name="joint_end_effector_type"
+    value="fixed"
+  />
+  <xacro:property
+    name="joint_end_effector_axis_xyz"
+    value="0 0 0"
+  />
+  <xacro:property
+    name="joint_end_effector_origin_xyz"
+    value="0 0 -0.1600"
+  />
+  <xacro:property
+    name="joint_end_effector_origin_rpy"
+    value="${J_PI} 0 ${J_PI/2}"
+  />
 
+  <xacro:macro
+    name="j2s6s200"
+    params="base_parent prefix:=j2s6s200"
+  >
+    <xacro:gazebo_config robot_namespace="${prefix}"/>
 
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_base"
+      link_mesh="${link_base_mesh}"
+      mesh_no="${link_base_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_base"
+      type="${joint_base_type}"
+      parent="${base_parent}"
+      child="${prefix}_link_base"
+      joint_axis_xyz="${joint_base_axis_xyz}"
+      joint_origin_xyz="${joint_base_origin_xyz}"
+      joint_origin_rpy="${joint_base_origin_rpy}"
+      joint_lower_limit="0"
+      joint_upper_limit="0"
+      joint_velocity_limit="0"
+      joint_torque_limit="0"
+      fixed="true"
+    />
 
-    <xacro:macro name="j2s6s200" params="base_parent prefix:=j2s6s200">
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_1"
+      link_mesh="${link_1_mesh}"
+      use_ring_mesh="true"
+      mesh_no="${link_1_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_1"
+      type="${joint_1_type}"
+      parent="${prefix}_link_base"
+      child="${prefix}_link_1"
+      joint_axis_xyz="${joint_1_axis_xyz}"
+      joint_origin_xyz="${joint_1_origin_xyz}"
+      joint_origin_rpy="${joint_1_origin_rpy}"
+      joint_lower_limit="${joint_1_lower_limit}"
+      joint_upper_limit="${joint_1_upper_limit}"
+      joint_velocity_limit="${joint_1_velocity_limit}"
+      joint_torque_limit="${joint_1_torque_limit}"
+    />
 
-        <xacro:gazebo_config robot_namespace="${prefix}"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_2"
+      link_mesh="${link_2_mesh}"
+      use_ring_mesh="true"
+      mesh_no="${link_2_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_2"
+      type="${joint_2_type}"
+      parent="${prefix}_link_1"
+      child="${prefix}_link_2"
+      joint_axis_xyz="${joint_2_axis_xyz}"
+      joint_origin_xyz="${joint_2_origin_xyz}"
+      joint_origin_rpy="${joint_2_origin_rpy}"
+      joint_lower_limit="${joint_2_lower_limit}"
+      joint_upper_limit="${joint_2_upper_limit}"
+      joint_velocity_limit="${joint_2_velocity_limit}"
+      joint_torque_limit="${joint_2_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_base" link_mesh="${link_base_mesh}" mesh_no="${link_base_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_base" type="${joint_base_type}" parent="${base_parent}" child="${prefix}_link_base" joint_axis_xyz="${joint_base_axis_xyz}" joint_origin_xyz="${joint_base_origin_xyz}" joint_origin_rpy="${joint_base_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0" joint_velocity_limit="0" joint_torque_limit="0" fixed="true"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_3"
+      link_mesh="${link_3_mesh}"
+      use_ring_mesh="true"
+      mesh_no="${link_3_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_3"
+      type="${joint_3_type}"
+      parent="${prefix}_link_2"
+      child="${prefix}_link_3"
+      joint_axis_xyz="${joint_3_axis_xyz}"
+      joint_origin_xyz="${joint_3_origin_xyz}"
+      joint_origin_rpy="${joint_3_origin_rpy}"
+      joint_lower_limit="${joint_3_lower_limit}"
+      joint_upper_limit="${joint_3_upper_limit}"
+      joint_velocity_limit="${joint_3_velocity_limit}"
+      joint_torque_limit="${joint_3_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_1" link_mesh="${link_1_mesh}" use_ring_mesh="true" mesh_no="${link_1_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_1" type="${joint_1_type}" parent="${prefix}_link_base" child="${prefix}_link_1" joint_axis_xyz="${joint_1_axis_xyz}" joint_origin_xyz="${joint_1_origin_xyz}" joint_origin_rpy="${joint_1_origin_rpy}" joint_lower_limit="${joint_1_lower_limit}" joint_upper_limit="${joint_1_upper_limit}" joint_velocity_limit="${joint_1_velocity_limit}" joint_torque_limit="${joint_1_torque_limit}"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_4"
+      link_mesh="${link_4_mesh}"
+      use_ring_mesh="true"
+      ring_mesh="ring_small"
+      mesh_no="${link_4_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_4"
+      type="${joint_4_type}"
+      parent="${prefix}_link_3"
+      child="${prefix}_link_4"
+      joint_axis_xyz="${joint_4_axis_xyz}"
+      joint_origin_xyz="${joint_4_origin_xyz}"
+      joint_origin_rpy="${joint_4_origin_rpy}"
+      joint_lower_limit="${joint_4_lower_limit}"
+      joint_upper_limit="${joint_4_upper_limit}"
+      joint_velocity_limit="${joint_4_velocity_limit}"
+      joint_torque_limit="${joint_4_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_2" link_mesh="${link_2_mesh}" use_ring_mesh="true" mesh_no="${link_2_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_2" type="${joint_2_type}" parent="${prefix}_link_1" child="${prefix}_link_2" joint_axis_xyz="${joint_2_axis_xyz}" joint_origin_xyz="${joint_2_origin_xyz}" joint_origin_rpy="${joint_2_origin_rpy}" joint_lower_limit="${joint_2_lower_limit}" joint_upper_limit="${joint_2_upper_limit}" joint_velocity_limit="${joint_2_velocity_limit}" joint_torque_limit="${joint_2_torque_limit}"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_5"
+      link_mesh="${link_5_mesh}"
+      use_ring_mesh="true"
+      ring_mesh="ring_small"
+      mesh_no="${link_5_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_5"
+      type="${joint_5_type}"
+      parent="${prefix}_link_4"
+      child="${prefix}_link_5"
+      joint_axis_xyz="${joint_5_axis_xyz}"
+      joint_origin_xyz="${joint_5_origin_xyz}"
+      joint_origin_rpy="${joint_5_origin_rpy}"
+      joint_lower_limit="${joint_5_lower_limit}"
+      joint_upper_limit="${joint_5_upper_limit}"
+      joint_velocity_limit="${joint_5_velocity_limit}"
+      joint_torque_limit="${joint_5_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_3" link_mesh="${link_3_mesh}" use_ring_mesh="true" mesh_no="${link_3_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_3" type="${joint_3_type}" parent="${prefix}_link_2" child="${prefix}_link_3" joint_axis_xyz="${joint_3_axis_xyz}" joint_origin_xyz="${joint_3_origin_xyz}" joint_origin_rpy="${joint_3_origin_rpy}" joint_lower_limit="${joint_3_lower_limit}" joint_upper_limit="${joint_3_upper_limit}" joint_velocity_limit="${joint_3_velocity_limit}" joint_torque_limit="${joint_3_torque_limit}"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_6"
+      link_mesh="${link_6_mesh}"
+      use_ring_mesh="true"
+      ring_mesh="ring_small"
+      mesh_no="${link_6_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_6"
+      type="${joint_6_type}"
+      parent="${prefix}_link_5"
+      child="${prefix}_link_6"
+      joint_axis_xyz="${joint_6_axis_xyz}"
+      joint_origin_xyz="${joint_6_origin_xyz}"
+      joint_origin_rpy="${joint_6_origin_rpy}"
+      joint_lower_limit="${joint_6_lower_limit}"
+      joint_upper_limit="${joint_6_upper_limit}"
+      joint_velocity_limit="${joint_6_velocity_limit}"
+      joint_torque_limit="${joint_6_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_4" link_mesh="${link_4_mesh}" use_ring_mesh="true" ring_mesh="ring_small" mesh_no="${link_4_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_4" type="${joint_4_type}" parent="${prefix}_link_3" child="${prefix}_link_4" joint_axis_xyz="${joint_4_axis_xyz}" joint_origin_xyz="${joint_4_origin_xyz}" joint_origin_rpy="${joint_4_origin_rpy}" joint_lower_limit="${joint_4_lower_limit}" joint_upper_limit="${joint_4_upper_limit}" joint_velocity_limit="${joint_4_velocity_limit}" joint_torque_limit="${joint_4_torque_limit}"/>
+    <xacro:kinova_virtual_link link_name="${prefix}_end_effector"/>
+    <xacro:kinova_virtual_joint
+      joint_name="${prefix}_joint_end_effector"
+      type="${joint_end_effector_type}"
+      parent="${prefix}_link_6"
+      child="${prefix}_end_effector"
+      joint_axis_xyz="${joint_end_effector_axis_xyz}"
+      joint_origin_xyz="${joint_end_effector_origin_xyz}"
+      joint_origin_rpy="${joint_end_effector_origin_rpy}"
+      joint_lower_limit="0"
+      joint_upper_limit="0"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_5" link_mesh="${link_5_mesh}" use_ring_mesh="true" ring_mesh="ring_small" mesh_no="${link_5_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_5" type="${joint_5_type}" parent="${prefix}_link_4" child="${prefix}_link_5" joint_axis_xyz="${joint_5_axis_xyz}" joint_origin_xyz="${joint_5_origin_xyz}" joint_origin_rpy="${joint_5_origin_rpy}" joint_lower_limit="${joint_5_lower_limit}" joint_upper_limit="${joint_5_upper_limit}" joint_velocity_limit="${joint_5_velocity_limit}" joint_torque_limit="${joint_5_torque_limit}"/>
-
-        <xacro:kinova_armlink link_name="${prefix}_link_6" link_mesh="${link_6_mesh}" use_ring_mesh="true" ring_mesh="ring_small" mesh_no="${link_6_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_6" type="${joint_6_type}" parent="${prefix}_link_5" child="${prefix}_link_6" joint_axis_xyz="${joint_6_axis_xyz}" joint_origin_xyz="${joint_6_origin_xyz}" joint_origin_rpy="${joint_6_origin_rpy}" joint_lower_limit="${joint_6_lower_limit}" joint_upper_limit="${joint_6_upper_limit}" joint_velocity_limit="${joint_6_velocity_limit}" joint_torque_limit="${joint_6_torque_limit}"/>
-
-
-        <xacro:kinova_virtual_link link_name="${prefix}_end_effector"/>
-        <xacro:kinova_virtual_joint joint_name="${prefix}_joint_end_effector" type="${joint_end_effector_type}" parent="${prefix}_link_6" child="${prefix}_end_effector" joint_axis_xyz="${joint_end_effector_axis_xyz}" joint_origin_xyz="${joint_end_effector_origin_xyz}" joint_origin_rpy="${joint_end_effector_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0"/>
-
-    <xacro:kinova_2fingers link_hand="${prefix}_link_6" prefix="${prefix}_"/>
-
-    </xacro:macro>
-
-
+    <xacro:kinova_2fingers
+      link_hand="${prefix}_link_6"
+      prefix="${prefix}_"
+    />
+  </xacro:macro>
 </root>

--- a/ada_description/urdf/j2s6s200_integration.xacro
+++ b/ada_description/urdf/j2s6s200_integration.xacro
@@ -1,25 +1,31 @@
 <?xml version="1.0"?>
 <!-- j2s6_2 refers to jaco v2 6DOF spherical 2fingers -->
+<robot
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
+  xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
+  xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+  xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
+  xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
+  xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
+  xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+  xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+  xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
+  xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
+  xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
+  xmlns:xacro="http://www.ros.org/wiki/xacro"
+  name="j2s6s300"
+>
+  <xacro:include filename="$(find ada_description)/urdf/j2s6s200.xacro"/>
 
-<robot xmlns:xi="http://www.w3.org/2001/XInclude"
-    xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
-    xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
-    xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-    xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
-    xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
-    xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
-    xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-    xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
-    xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
-    xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
-    xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-    xmlns:xacro="http://www.ros.org/wiki/xacro" name="j2s6s300">
-
-
-    <xacro:include filename="$(find ada_description)/urdf/j2s6s200.xacro"/>
-
-    <xacro:arg name="arm_root" default="base_link" />
-    <xacro:property name="arm_root" value="$(arg arm_root)" />
-    <link name="${arm_root}"/>
-    <xacro:j2s6s200 base_parent="${arm_root}"/>
+  <xacro:arg
+    name="arm_root"
+    default="base_link"
+  />
+  <xacro:property
+    name="arm_root"
+    value="$(arg arm_root)"
+  />
+  <link name="${arm_root}"/>
+  <xacro:j2s6s200 base_parent="${arm_root}"/>
 </robot>

--- a/ada_description/urdf/j2s6s200_standalone.xacro
+++ b/ada_description/urdf/j2s6s200_standalone.xacro
@@ -1,22 +1,21 @@
 <?xml version="1.0"?>
 <!-- j2s6_2 refers to jaco v2 6DOF spherical 2fingers -->
-
-
-<robot xmlns:xi="http://www.w3.org/2001/XInclude"
-	xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
-    xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
-	xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-	xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
-    xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
-    xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
-	xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-	xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
-	xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
-    xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
-    xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-	xmlns:xacro="http://www.ros.org/wiki/xacro" name="j2s6s200">
-
-
+<robot
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
+  xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
+  xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+  xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
+  xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
+  xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
+  xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+  xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+  xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
+  xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
+  xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
+  xmlns:xacro="http://www.ros.org/wiki/xacro"
+  name="j2s6s200"
+>
   <xacro:include filename="$(find ada_description)/urdf/j2s6s200.xacro"/>
 
   <link name="root"/>
@@ -24,14 +23,22 @@
   <!-- for gazebo -->
   <link name="world"/>
 
-  <joint name="connect_root_and_world" type="fixed">
-    <child link="root" />
-    <parent link="world" />
-    <origin xyz="0 0 0" rpy="0 0 0" />
+  <joint
+    name="connect_root_and_world"
+    type="fixed"
+  >
+    <child link="root"/>
+    <parent link="world"/>
+    <origin
+      xyz="0 0 0"
+      rpy="0 0 0"
+    />
   </joint>
 
-  <xacro:property name="robot_root" value="root" />
+  <xacro:property
+    name="robot_root"
+    value="root"
+  />
 
-  <xacro:j2s6s200  base_parent="${robot_root}"/>
-
+  <xacro:j2s6s200 base_parent="${robot_root}"/>
 </robot>

--- a/ada_description/urdf/j2s6s300.xacro
+++ b/ada_description/urdf/j2s6s300.xacro
@@ -1,155 +1,519 @@
 <?xml version="1.0"?>
 <!-- j2_6s refers to jaco v2 6DOF spherical -->
+<robot
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
+  xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
+  xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+  xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
+  xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
+  xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
+  xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+  xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+  xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
+  xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
+  xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
+  xmlns:xacro="http://www.ros.org/wiki/xacro"
+>
+  <xacro:include filename="$(find ada_description)/urdf/kinova_common.xacro"/>
+  <xacro:include filename="$(find ada_description)/urdf/kinova_finger_set.xacro"/>
 
+  <!-- Import all Gazebo-customization elements -->
+  <xacro:include filename="$(find ada_description)/urdf/kinova.gazebo"/>
 
-<robot xmlns:xi="http://www.w3.org/2001/XInclude"
-    xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
-    xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
-    xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-    xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
-    xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
-    xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
-    xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-    xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
-    xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
-    xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
-    xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-    xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:property
+    name="link_base_mesh"
+    value="base"
+  />
+  <xacro:property
+    name="link_1_mesh"
+    value="shoulder"
+  />
+  <xacro:property
+    name="link_2_mesh"
+    value="arm"
+  />
+  <xacro:property
+    name="link_3_mesh"
+    value="forearm"
+  />
+  <xacro:property
+    name="link_4_mesh"
+    value="wrist_spherical_1"
+  />
+  <xacro:property
+    name="link_5_mesh"
+    value="wrist_spherical_2"
+  />
+  <xacro:property
+    name="link_6_mesh"
+    value="hand_3finger"
+  />
 
-    <xacro:include filename="$(find ada_description)/urdf/kinova_common.xacro" />
-    <xacro:include filename="$(find ada_description)/urdf/kinova_finger_set.xacro" />
-
-    <!-- Import all Gazebo-customization elements -->
-    <xacro:include filename="$(find ada_description)/urdf/kinova.gazebo" />
-
-    <xacro:property name="link_base_mesh" value="base" />
-    <xacro:property name="link_1_mesh" value="shoulder" />
-    <xacro:property name="link_2_mesh" value="arm" />
-    <xacro:property name="link_3_mesh" value="forearm" />
-    <xacro:property name="link_4_mesh" value="wrist_spherical_1" />
-    <xacro:property name="link_5_mesh" value="wrist_spherical_2" />
-    <xacro:property name="link_6_mesh" value="hand_3finger" />
-
-    <!--Used for conditional arguments for setting inertial parameters
+  <!--Used for conditional arguments for setting inertial parameters
         base 0, shoulder 1, arm 2, forearm 3, wrist 4, arm_mico 5,
         arm_half1 (7dof)	6, arm_half2 (7dof) 7, wrist_spherical_1  8, wrist_spherical_2  9
         fore_arm_mico 10,
         hand 3 finger 55, hand_2finger 56, finger_proximal 57, finger_distal 58
     -->
-    <xacro:property name="link_base_mesh_no" value="0" />
-    <xacro:property name="link_1_mesh_no" value="1" />
-    <xacro:property name="link_2_mesh_no" value="2" />
-    <xacro:property name="link_3_mesh_no" value="3" />
-    <xacro:property name="link_4_mesh_no" value="8" />
-    <xacro:property name="link_5_mesh_no" value="9" />
-    <xacro:property name="link_6_mesh_no" value="55" />
+  <xacro:property
+    name="link_base_mesh_no"
+    value="0"
+  />
+  <xacro:property
+    name="link_1_mesh_no"
+    value="1"
+  />
+  <xacro:property
+    name="link_2_mesh_no"
+    value="2"
+  />
+  <xacro:property
+    name="link_3_mesh_no"
+    value="3"
+  />
+  <xacro:property
+    name="link_4_mesh_no"
+    value="8"
+  />
+  <xacro:property
+    name="link_5_mesh_no"
+    value="9"
+  />
+  <xacro:property
+    name="link_6_mesh_no"
+    value="55"
+  />
 
-    <xacro:property name="joint_base" value="joint_base" />
-    <xacro:property name="joint_base_type" value="fixed" />
-    <xacro:property name="joint_base_axis_xyz" value="0 0 0" />
-    <xacro:property name="joint_base_origin_xyz" value="0 0 0" />
-    <xacro:property name="joint_base_origin_rpy" value="0 0 0" />
+  <xacro:property
+    name="joint_base"
+    value="joint_base"
+  />
+  <xacro:property
+    name="joint_base_type"
+    value="fixed"
+  />
+  <xacro:property
+    name="joint_base_axis_xyz"
+    value="0 0 0"
+  />
+  <xacro:property
+    name="joint_base_origin_xyz"
+    value="0 0 0"
+  />
+  <xacro:property
+    name="joint_base_origin_rpy"
+    value="0 0 0"
+  />
 
-    <xacro:property name="joint_1" value="joint_1" />
-    <xacro:property name="joint_1_type" value="continuous" />
-    <xacro:property name="joint_1_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_1_origin_xyz" value="0 0 0.15675" />
-    <xacro:property name="joint_1_origin_rpy" value="0 ${J_PI} 0" />
-    <xacro:property name="joint_1_lower_limit" value="${-2*J_PI}" />
-    <xacro:property name="joint_1_upper_limit" value="${2*J_PI}" />
-    <xacro:property name="joint_1_velocity_limit" value="${36*J_PI/180}" />
-    <xacro:property name="joint_1_torque_limit" value="40" />
+  <xacro:property
+    name="joint_1"
+    value="joint_1"
+  />
+  <xacro:property
+    name="joint_1_type"
+    value="continuous"
+  />
+  <xacro:property
+    name="joint_1_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_1_origin_xyz"
+    value="0 0 0.15675"
+  />
+  <xacro:property
+    name="joint_1_origin_rpy"
+    value="0 ${J_PI} 0"
+  />
+  <xacro:property
+    name="joint_1_lower_limit"
+    value="${-2*J_PI}"
+  />
+  <xacro:property
+    name="joint_1_upper_limit"
+    value="${2*J_PI}"
+  />
+  <xacro:property
+    name="joint_1_velocity_limit"
+    value="${36*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_1_torque_limit"
+    value="40"
+  />
 
-    <xacro:property name="joint_2" value="joint_2" />
-    <xacro:property name="joint_2_type" value="revolute" />
-    <xacro:property name="joint_2_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_2_origin_xyz" value="0 0.0016 -0.11875" />
-    <xacro:property name="joint_2_origin_rpy" value="${-J_PI/2} 0 ${J_PI}"/>
-    <xacro:property name="joint_2_lower_limit" value="${47/180*J_PI}" />
-    <xacro:property name="joint_2_upper_limit" value="${313/180*J_PI}" />
-    <xacro:property name="joint_2_velocity_limit" value="${36*J_PI/180}" />
-    <xacro:property name="joint_2_torque_limit" value="80" />
+  <xacro:property
+    name="joint_2"
+    value="joint_2"
+  />
+  <xacro:property
+    name="joint_2_type"
+    value="revolute"
+  />
+  <xacro:property
+    name="joint_2_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_2_origin_xyz"
+    value="0 0.0016 -0.11875"
+  />
+  <xacro:property
+    name="joint_2_origin_rpy"
+    value="${-J_PI/2} 0 ${J_PI}"
+  />
+  <xacro:property
+    name="joint_2_lower_limit"
+    value="${47/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_2_upper_limit"
+    value="${313/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_2_velocity_limit"
+    value="${36*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_2_torque_limit"
+    value="80"
+  />
 
-    <xacro:property name="joint_3" value="joint_3" />
-    <xacro:property name="joint_3_type" value="revolute" />
-    <xacro:property name="joint_3_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_3_origin_xyz" value="0 -0.410 0" />
-    <xacro:property name="joint_3_origin_rpy" value="0 ${J_PI} 0" />
-    <xacro:property name="joint_3_lower_limit" value="${19/180*J_PI}" />
-    <xacro:property name="joint_3_upper_limit" value="${341/180*J_PI}" />
-    <xacro:property name="joint_3_velocity_limit" value="${36*J_PI/180}" />
-    <xacro:property name="joint_3_torque_limit" value="40" />
+  <xacro:property
+    name="joint_3"
+    value="joint_3"
+  />
+  <xacro:property
+    name="joint_3_type"
+    value="revolute"
+  />
+  <xacro:property
+    name="joint_3_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_3_origin_xyz"
+    value="0 -0.410 0"
+  />
+  <xacro:property
+    name="joint_3_origin_rpy"
+    value="0 ${J_PI} 0"
+  />
+  <xacro:property
+    name="joint_3_lower_limit"
+    value="${19/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_3_upper_limit"
+    value="${341/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_3_velocity_limit"
+    value="${36*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_3_torque_limit"
+    value="40"
+  />
 
-    <xacro:property name="joint_4" value="joint_4" />
-    <xacro:property name="joint_4_type" value="continuous" />
-    <xacro:property name="joint_4_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_4_origin_xyz" value="0 0.2073 -0.0114" />
-    <xacro:property name="joint_4_origin_rpy" value="${-J_PI/2} 0 ${J_PI}" />
-    <xacro:property name="joint_4_lower_limit" value="${-2*J_PI}" />
-    <xacro:property name="joint_4_upper_limit" value="${2*J_PI}" />
-    <xacro:property name="joint_4_velocity_limit" value="${48*J_PI/180}" />
-    <xacro:property name="joint_4_torque_limit" value="20" />
+  <xacro:property
+    name="joint_4"
+    value="joint_4"
+  />
+  <xacro:property
+    name="joint_4_type"
+    value="continuous"
+  />
+  <xacro:property
+    name="joint_4_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_4_origin_xyz"
+    value="0 0.2073 -0.0114"
+  />
+  <xacro:property
+    name="joint_4_origin_rpy"
+    value="${-J_PI/2} 0 ${J_PI}"
+  />
+  <xacro:property
+    name="joint_4_lower_limit"
+    value="${-2*J_PI}"
+  />
+  <xacro:property
+    name="joint_4_upper_limit"
+    value="${2*J_PI}"
+  />
+  <xacro:property
+    name="joint_4_velocity_limit"
+    value="${48*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_4_torque_limit"
+    value="20"
+  />
 
-    <xacro:property name="joint_5" value="joint_5" />
-    <xacro:property name="joint_5_type" value="revolute" />
-    <xacro:property name="joint_5_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_5_origin_xyz" value="0 0 -0.10375" />
-    <xacro:property name="joint_5_origin_rpy" value="${J_PI/2} 0 ${J_PI}" />
-    <xacro:property name="joint_5_lower_limit" value="${30/180*J_PI}" />
-    <xacro:property name="joint_5_upper_limit" value="${330/180*J_PI}" />
-    <xacro:property name="joint_5_velocity_limit" value="${48*J_PI/180}" />
-    <xacro:property name="joint_5_torque_limit" value="20" />
+  <xacro:property
+    name="joint_5"
+    value="joint_5"
+  />
+  <xacro:property
+    name="joint_5_type"
+    value="revolute"
+  />
+  <xacro:property
+    name="joint_5_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_5_origin_xyz"
+    value="0 0 -0.10375"
+  />
+  <xacro:property
+    name="joint_5_origin_rpy"
+    value="${J_PI/2} 0 ${J_PI}"
+  />
+  <xacro:property
+    name="joint_5_lower_limit"
+    value="${30/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_5_upper_limit"
+    value="${330/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_5_velocity_limit"
+    value="${48*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_5_torque_limit"
+    value="20"
+  />
 
-    <xacro:property name="joint_6" value="joint_6" />
-    <xacro:property name="joint_6_type" value="continuous" />
-    <xacro:property name="joint_6_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_6_origin_xyz" value="0 0.10375 0" />
-    <xacro:property name="joint_6_origin_rpy" value="${-J_PI/2} 0 ${J_PI}" />
-    <xacro:property name="joint_6_lower_limit" value="${-2*J_PI}" />
-    <xacro:property name="joint_6_upper_limit" value="${2*J_PI}" />
-    <xacro:property name="joint_6_velocity_limit" value="${48*J_PI/180}" />
-    <xacro:property name="joint_6_torque_limit" value="20" />
+  <xacro:property
+    name="joint_6"
+    value="joint_6"
+  />
+  <xacro:property
+    name="joint_6_type"
+    value="continuous"
+  />
+  <xacro:property
+    name="joint_6_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_6_origin_xyz"
+    value="0 0.10375 0"
+  />
+  <xacro:property
+    name="joint_6_origin_rpy"
+    value="${-J_PI/2} 0 ${J_PI}"
+  />
+  <xacro:property
+    name="joint_6_lower_limit"
+    value="${-2*J_PI}"
+  />
+  <xacro:property
+    name="joint_6_upper_limit"
+    value="${2*J_PI}"
+  />
+  <xacro:property
+    name="joint_6_velocity_limit"
+    value="${48*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_6_torque_limit"
+    value="20"
+  />
 
-    <xacro:property name="joint_end_effector" value="end_effector_offset" />
-    <xacro:property name="joint_end_effector_type" value="fixed" />
-    <xacro:property name="joint_end_effector_axis_xyz" value="0 0 0" />
-    <xacro:property name="joint_end_effector_origin_xyz" value="0 0 -0.1600" />
-    <xacro:property name="joint_end_effector_origin_rpy" value="${J_PI} 0 ${J_PI/2}" />
+  <xacro:property
+    name="joint_end_effector"
+    value="end_effector_offset"
+  />
+  <xacro:property
+    name="joint_end_effector_type"
+    value="fixed"
+  />
+  <xacro:property
+    name="joint_end_effector_axis_xyz"
+    value="0 0 0"
+  />
+  <xacro:property
+    name="joint_end_effector_origin_xyz"
+    value="0 0 -0.1600"
+  />
+  <xacro:property
+    name="joint_end_effector_origin_rpy"
+    value="${J_PI} 0 ${J_PI/2}"
+  />
 
+  <xacro:macro
+    name="j2s6s300"
+    params="base_parent prefix:=j2s6s300"
+  >
+    <xacro:gazebo_config robot_namespace="${prefix}"/>
 
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_base"
+      link_mesh="${link_base_mesh}"
+      mesh_no="${link_base_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_base"
+      type="${joint_base_type}"
+      parent="${base_parent}"
+      child="${prefix}_link_base"
+      joint_axis_xyz="${joint_base_axis_xyz}"
+      joint_origin_xyz="${joint_base_origin_xyz}"
+      joint_origin_rpy="${joint_base_origin_rpy}"
+      joint_lower_limit="0"
+      joint_upper_limit="0"
+      joint_velocity_limit="0"
+      joint_torque_limit="0"
+      fixed="true"
+    />
 
-    <xacro:macro name="j2s6s300" params="base_parent prefix:=j2s6s300">
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_1"
+      link_mesh="${link_1_mesh}"
+      use_ring_mesh="true"
+      mesh_no="${link_1_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_1"
+      type="${joint_1_type}"
+      parent="${prefix}_link_base"
+      child="${prefix}_link_1"
+      joint_axis_xyz="${joint_1_axis_xyz}"
+      joint_origin_xyz="${joint_1_origin_xyz}"
+      joint_origin_rpy="${joint_1_origin_rpy}"
+      joint_lower_limit="${joint_1_lower_limit}"
+      joint_upper_limit="${joint_1_upper_limit}"
+      joint_velocity_limit="${joint_1_velocity_limit}"
+      joint_torque_limit="${joint_1_torque_limit}"
+    />
 
-        <xacro:gazebo_config robot_namespace="${prefix}"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_2"
+      link_mesh="${link_2_mesh}"
+      use_ring_mesh="true"
+      mesh_no="${link_2_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_2"
+      type="${joint_2_type}"
+      parent="${prefix}_link_1"
+      child="${prefix}_link_2"
+      joint_axis_xyz="${joint_2_axis_xyz}"
+      joint_origin_xyz="${joint_2_origin_xyz}"
+      joint_origin_rpy="${joint_2_origin_rpy}"
+      joint_lower_limit="${joint_2_lower_limit}"
+      joint_upper_limit="${joint_2_upper_limit}"
+      joint_velocity_limit="${joint_2_velocity_limit}"
+      joint_torque_limit="${joint_2_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_base" link_mesh="${link_base_mesh}" mesh_no="${link_base_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_base" type="${joint_base_type}" parent="${base_parent}" child="${prefix}_link_base" joint_axis_xyz="${joint_base_axis_xyz}" joint_origin_xyz="${joint_base_origin_xyz}" joint_origin_rpy="${joint_base_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0" joint_velocity_limit="0" joint_torque_limit="0" fixed="true"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_3"
+      link_mesh="${link_3_mesh}"
+      use_ring_mesh="true"
+      mesh_no="${link_3_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_3"
+      type="${joint_3_type}"
+      parent="${prefix}_link_2"
+      child="${prefix}_link_3"
+      joint_axis_xyz="${joint_3_axis_xyz}"
+      joint_origin_xyz="${joint_3_origin_xyz}"
+      joint_origin_rpy="${joint_3_origin_rpy}"
+      joint_lower_limit="${joint_3_lower_limit}"
+      joint_upper_limit="${joint_3_upper_limit}"
+      joint_velocity_limit="${joint_3_velocity_limit}"
+      joint_torque_limit="${joint_3_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_1" link_mesh="${link_1_mesh}" use_ring_mesh="true" mesh_no="${link_1_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_1" type="${joint_1_type}" parent="${prefix}_link_base" child="${prefix}_link_1" joint_axis_xyz="${joint_1_axis_xyz}" joint_origin_xyz="${joint_1_origin_xyz}" joint_origin_rpy="${joint_1_origin_rpy}" joint_lower_limit="${joint_1_lower_limit}" joint_upper_limit="${joint_1_upper_limit}" joint_velocity_limit="${joint_1_velocity_limit}" joint_torque_limit="${joint_1_torque_limit}"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_4"
+      link_mesh="${link_4_mesh}"
+      use_ring_mesh="true"
+      ring_mesh="ring_small"
+      mesh_no="${link_4_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_4"
+      type="${joint_4_type}"
+      parent="${prefix}_link_3"
+      child="${prefix}_link_4"
+      joint_axis_xyz="${joint_4_axis_xyz}"
+      joint_origin_xyz="${joint_4_origin_xyz}"
+      joint_origin_rpy="${joint_4_origin_rpy}"
+      joint_lower_limit="${joint_4_lower_limit}"
+      joint_upper_limit="${joint_4_upper_limit}"
+      joint_velocity_limit="${joint_4_velocity_limit}"
+      joint_torque_limit="${joint_4_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_2" link_mesh="${link_2_mesh}" use_ring_mesh="true" mesh_no="${link_2_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_2" type="${joint_2_type}" parent="${prefix}_link_1" child="${prefix}_link_2" joint_axis_xyz="${joint_2_axis_xyz}" joint_origin_xyz="${joint_2_origin_xyz}" joint_origin_rpy="${joint_2_origin_rpy}" joint_lower_limit="${joint_2_lower_limit}" joint_upper_limit="${joint_2_upper_limit}" joint_velocity_limit="${joint_2_velocity_limit}" joint_torque_limit="${joint_2_torque_limit}"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_5"
+      link_mesh="${link_5_mesh}"
+      use_ring_mesh="true"
+      ring_mesh="ring_small"
+      mesh_no="${link_5_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_5"
+      type="${joint_5_type}"
+      parent="${prefix}_link_4"
+      child="${prefix}_link_5"
+      joint_axis_xyz="${joint_5_axis_xyz}"
+      joint_origin_xyz="${joint_5_origin_xyz}"
+      joint_origin_rpy="${joint_5_origin_rpy}"
+      joint_lower_limit="${joint_5_lower_limit}"
+      joint_upper_limit="${joint_5_upper_limit}"
+      joint_velocity_limit="${joint_5_velocity_limit}"
+      joint_torque_limit="${joint_5_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_3" link_mesh="${link_3_mesh}" use_ring_mesh="true" mesh_no="${link_3_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_3" type="${joint_3_type}" parent="${prefix}_link_2" child="${prefix}_link_3" joint_axis_xyz="${joint_3_axis_xyz}" joint_origin_xyz="${joint_3_origin_xyz}" joint_origin_rpy="${joint_3_origin_rpy}" joint_lower_limit="${joint_3_lower_limit}" joint_upper_limit="${joint_3_upper_limit}" joint_velocity_limit="${joint_3_velocity_limit}" joint_torque_limit="${joint_3_torque_limit}"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_6"
+      link_mesh="${link_6_mesh}"
+      use_ring_mesh="true"
+      ring_mesh="ring_small"
+      mesh_no="${link_6_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_6"
+      type="${joint_6_type}"
+      parent="${prefix}_link_5"
+      child="${prefix}_link_6"
+      joint_axis_xyz="${joint_6_axis_xyz}"
+      joint_origin_xyz="${joint_6_origin_xyz}"
+      joint_origin_rpy="${joint_6_origin_rpy}"
+      joint_lower_limit="${joint_6_lower_limit}"
+      joint_upper_limit="${joint_6_upper_limit}"
+      joint_velocity_limit="${joint_6_velocity_limit}"
+      joint_torque_limit="${joint_6_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_4" link_mesh="${link_4_mesh}" use_ring_mesh="true" ring_mesh="ring_small" mesh_no="${link_4_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_4" type="${joint_4_type}" parent="${prefix}_link_3" child="${prefix}_link_4" joint_axis_xyz="${joint_4_axis_xyz}" joint_origin_xyz="${joint_4_origin_xyz}" joint_origin_rpy="${joint_4_origin_rpy}" joint_lower_limit="${joint_4_lower_limit}" joint_upper_limit="${joint_4_upper_limit}" joint_velocity_limit="${joint_4_velocity_limit}" joint_torque_limit="${joint_4_torque_limit}"/>
+    <xacro:kinova_virtual_link link_name="${prefix}_end_effector"/>
+    <xacro:kinova_virtual_joint
+      joint_name="${prefix}_joint_end_effector"
+      type="${joint_end_effector_type}"
+      parent="${prefix}_link_6"
+      child="${prefix}_end_effector"
+      joint_axis_xyz="${joint_end_effector_axis_xyz}"
+      joint_origin_xyz="${joint_end_effector_origin_xyz}"
+      joint_origin_rpy="${joint_end_effector_origin_rpy}"
+      joint_lower_limit="0"
+      joint_upper_limit="0"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_5" link_mesh="${link_5_mesh}" use_ring_mesh="true" ring_mesh="ring_small" mesh_no="${link_5_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_5" type="${joint_5_type}" parent="${prefix}_link_4" child="${prefix}_link_5" joint_axis_xyz="${joint_5_axis_xyz}" joint_origin_xyz="${joint_5_origin_xyz}" joint_origin_rpy="${joint_5_origin_rpy}" joint_lower_limit="${joint_5_lower_limit}" joint_upper_limit="${joint_5_upper_limit}" joint_velocity_limit="${joint_5_velocity_limit}" joint_torque_limit="${joint_5_torque_limit}"/>
-
-        <xacro:kinova_armlink link_name="${prefix}_link_6" link_mesh="${link_6_mesh}" use_ring_mesh="true" ring_mesh="ring_small" mesh_no="${link_6_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_6" type="${joint_6_type}" parent="${prefix}_link_5" child="${prefix}_link_6" joint_axis_xyz="${joint_6_axis_xyz}" joint_origin_xyz="${joint_6_origin_xyz}" joint_origin_rpy="${joint_6_origin_rpy}" joint_lower_limit="${joint_6_lower_limit}" joint_upper_limit="${joint_6_upper_limit}" joint_velocity_limit="${joint_6_velocity_limit}" joint_torque_limit="${joint_6_torque_limit}"/>
-
-
-        <xacro:kinova_virtual_link link_name="${prefix}_end_effector"/>
-        <xacro:kinova_virtual_joint joint_name="${prefix}_joint_end_effector" type="${joint_end_effector_type}" parent="${prefix}_link_6" child="${prefix}_end_effector" joint_axis_xyz="${joint_end_effector_axis_xyz}" joint_origin_xyz="${joint_end_effector_origin_xyz}" joint_origin_rpy="${joint_end_effector_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0"/>
-
-    <xacro:kinova_3fingers link_hand="${prefix}_link_6" prefix="${prefix}_"/>
-
-    </xacro:macro>
-
-
+    <xacro:kinova_3fingers
+      link_hand="${prefix}_link_6"
+      prefix="${prefix}_"
+    />
+  </xacro:macro>
 </robot>

--- a/ada_description/urdf/j2s6s300_integration.xacro
+++ b/ada_description/urdf/j2s6s300_integration.xacro
@@ -1,25 +1,31 @@
 <?xml version="1.0"?>
 <!-- j2s6_3 refers to jaco v2 6DOF spherical 3fingers -->
+<robot
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
+  xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
+  xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+  xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
+  xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
+  xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
+  xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+  xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+  xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
+  xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
+  xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
+  xmlns:xacro="http://www.ros.org/wiki/xacro"
+  name="j2s6s300"
+>
+  <xacro:include filename="$(find ada_description)/urdf/j2s6s300.xacro"/>
 
-<robot xmlns:xi="http://www.w3.org/2001/XInclude"
-    xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
-    xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
-    xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-    xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
-    xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
-    xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
-    xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-    xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
-    xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
-    xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
-    xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-    xmlns:xacro="http://www.ros.org/wiki/xacro" name="j2s6s300">
-
-
-    <xacro:include filename="$(find ada_description)/urdf/j2s6s300.xacro"/>
-
-    <xacro:arg name="arm_root" default="base_link" />
-    <xacro:property name="arm_root" value="$(arg arm_root)" />
-    <link name="${arm_root}"/>
-    <xacro:j2s6s300 base_parent="${arm_root}"/>
+  <xacro:arg
+    name="arm_root"
+    default="base_link"
+  />
+  <xacro:property
+    name="arm_root"
+    value="$(arg arm_root)"
+  />
+  <link name="${arm_root}"/>
+  <xacro:j2s6s300 base_parent="${arm_root}"/>
 </robot>

--- a/ada_description/urdf/j2s6s300_standalone.xacro
+++ b/ada_description/urdf/j2s6s300_standalone.xacro
@@ -1,22 +1,21 @@
 <?xml version="1.0"?>
 <!-- j2s6_3 refers to jaco v2 6DOF spherical 3fingers -->
-
-
-<robot xmlns:xi="http://www.w3.org/2001/XInclude"
-	xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
-    xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
-	xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-	xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
-    xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
-    xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
-	xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-	xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
-	xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
-    xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
-    xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-	xmlns:xacro="http://www.ros.org/wiki/xacro" name="j2s6s300">
-
-
+<robot
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
+  xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
+  xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+  xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
+  xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
+  xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
+  xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+  xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+  xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
+  xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
+  xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
+  xmlns:xacro="http://www.ros.org/wiki/xacro"
+  name="j2s6s300"
+>
   <xacro:include filename="$(find ada_description)/urdf/j2s6s300.xacro"/>
 
   <link name="root"/>
@@ -24,14 +23,22 @@
   <!-- for gazebo -->
   <link name="world"/>
 
-  <joint name="connect_root_and_world" type="fixed">
-    <child link="root" />
-    <parent link="world" />
-    <origin xyz="0 0 0" rpy="0 0 0" />
+  <joint
+    name="connect_root_and_world"
+    type="fixed"
+  >
+    <child link="root"/>
+    <parent link="world"/>
+    <origin
+      xyz="0 0 0"
+      rpy="0 0 0"
+    />
   </joint>
 
-  <xacro:property name="robot_root" value="root" />
+  <xacro:property
+    name="robot_root"
+    value="root"
+  />
 
-  <xacro:j2s6s300  base_parent="${robot_root}"/>
-
+  <xacro:j2s6s300 base_parent="${robot_root}"/>
 </robot>

--- a/ada_description/urdf/j2s7s300.xacro
+++ b/ada_description/urdf/j2s7s300.xacro
@@ -1,169 +1,584 @@
 <?xml version="1.0"?>
 <!-- j2_s7 refers to jaco v2 7DOF spherical -->
+<root
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
+  xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
+  xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+  xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
+  xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
+  xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
+  xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+  xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+  xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
+  xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
+  xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
+  xmlns:xacro="http://www.ros.org/wiki/xacro"
+>
+  <xacro:include filename="$(find ada_description)/urdf/kinova_common.xacro"/>
+  <xacro:include filename="$(find ada_description)/urdf/kinova_finger_set.xacro"/>
 
+  <!-- Import all Gazebo-customization elements -->
+  <xacro:include filename="$(find ada_description)/urdf/kinova.gazebo"/>
 
-<root xmlns:xi="http://www.w3.org/2001/XInclude"
-    xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
-    xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
-    xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-    xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
-    xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
-    xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
-    xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-    xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
-    xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
-    xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
-    xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-    xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:property
+    name="link_base_mesh"
+    value="base"
+  />
+  <xacro:property
+    name="link_1_mesh"
+    value="shoulder"
+  />
+  <xacro:property
+    name="link_2_mesh"
+    value="arm_half_1"
+  />
+  <xacro:property
+    name="link_3_mesh"
+    value="arm_half_2"
+  />
+  <xacro:property
+    name="link_4_mesh"
+    value="forearm"
+  />
+  <xacro:property
+    name="link_5_mesh"
+    value="wrist_spherical_1"
+  />
+  <xacro:property
+    name="link_6_mesh"
+    value="wrist_spherical_2"
+  />
+  <xacro:property
+    name="link_7_mesh"
+    value="hand_3finger"
+  />
 
-    <xacro:include filename="$(find ada_description)/urdf/kinova_common.xacro" />
-    <xacro:include filename="$(find ada_description)/urdf/kinova_finger_set.xacro" />
-
-    <!-- Import all Gazebo-customization elements -->
-    <xacro:include filename="$(find ada_description)/urdf/kinova.gazebo" />
-
-    <xacro:property name="link_base_mesh" value="base" />
-    <xacro:property name="link_1_mesh" value="shoulder" />
-    <xacro:property name="link_2_mesh" value="arm_half_1" />
-    <xacro:property name="link_3_mesh" value="arm_half_2" />
-    <xacro:property name="link_4_mesh" value="forearm" />
-    <xacro:property name="link_5_mesh" value="wrist_spherical_1" />
-    <xacro:property name="link_6_mesh" value="wrist_spherical_2" />
-    <xacro:property name="link_7_mesh" value="hand_3finger" />
-
-    <!--Used for conditional arguments for setting inertial parameters
+  <!--Used for conditional arguments for setting inertial parameters
         base 0, shoulder 1, arm 2, forearm 3, wrist 4, arm_mico 5,
         arm_half1 (7dof)	6, arm_half2 (7dof) 7, wrist_spherical_1  8, wrist_spherical_2  9
         fore_arm_mico 10,
         hand 3 finger 55, hand_2finger 56, finger_proximal 57, finger_distal 58
     -->
-    <xacro:property name="link_base_mesh_no" value="0" />
-    <xacro:property name="link_1_mesh_no" value="1" />
-    <xacro:property name="link_2_mesh_no" value="6" />
-    <xacro:property name="link_3_mesh_no" value="7" />
-    <xacro:property name="link_4_mesh_no" value="3" />
-    <xacro:property name="link_5_mesh_no" value="8" />
-    <xacro:property name="link_6_mesh_no" value="9" />
-    <xacro:property name="link_7_mesh_no" value="55" />
+  <xacro:property
+    name="link_base_mesh_no"
+    value="0"
+  />
+  <xacro:property
+    name="link_1_mesh_no"
+    value="1"
+  />
+  <xacro:property
+    name="link_2_mesh_no"
+    value="6"
+  />
+  <xacro:property
+    name="link_3_mesh_no"
+    value="7"
+  />
+  <xacro:property
+    name="link_4_mesh_no"
+    value="3"
+  />
+  <xacro:property
+    name="link_5_mesh_no"
+    value="8"
+  />
+  <xacro:property
+    name="link_6_mesh_no"
+    value="9"
+  />
+  <xacro:property
+    name="link_7_mesh_no"
+    value="55"
+  />
 
-    <xacro:property name="joint_base" value="joint_base" />
-    <xacro:property name="joint_base_type" value="fixed" />
-    <xacro:property name="joint_base_axis_xyz" value="0 0 0" />
-    <xacro:property name="joint_base_origin_xyz" value="0 0 0" />
-    <xacro:property name="joint_base_origin_rpy" value="0 0 0" />
+  <xacro:property
+    name="joint_base"
+    value="joint_base"
+  />
+  <xacro:property
+    name="joint_base_type"
+    value="fixed"
+  />
+  <xacro:property
+    name="joint_base_axis_xyz"
+    value="0 0 0"
+  />
+  <xacro:property
+    name="joint_base_origin_xyz"
+    value="0 0 0"
+  />
+  <xacro:property
+    name="joint_base_origin_rpy"
+    value="0 0 0"
+  />
 
-    <xacro:property name="joint_1" value="joint_1" />
-    <xacro:property name="joint_1_type" value="continuous" />
-    <xacro:property name="joint_1_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_1_origin_xyz" value="0 0 0.15675" />
-    <xacro:property name="joint_1_origin_rpy" value="0 ${J_PI} 0" />
-    <xacro:property name="joint_1_lower_limit" value="${-2*J_PI}" />
-    <xacro:property name="joint_1_upper_limit" value="${2*J_PI}" />
-    <xacro:property name="joint_1_velocity_limit" value="${36*J_PI/180}" />
-    <xacro:property name="joint_1_torque_limit" value="40" />
+  <xacro:property
+    name="joint_1"
+    value="joint_1"
+  />
+  <xacro:property
+    name="joint_1_type"
+    value="continuous"
+  />
+  <xacro:property
+    name="joint_1_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_1_origin_xyz"
+    value="0 0 0.15675"
+  />
+  <xacro:property
+    name="joint_1_origin_rpy"
+    value="0 ${J_PI} 0"
+  />
+  <xacro:property
+    name="joint_1_lower_limit"
+    value="${-2*J_PI}"
+  />
+  <xacro:property
+    name="joint_1_upper_limit"
+    value="${2*J_PI}"
+  />
+  <xacro:property
+    name="joint_1_velocity_limit"
+    value="${36*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_1_torque_limit"
+    value="40"
+  />
 
-    <xacro:property name="joint_2" value="joint_2" />
-    <xacro:property name="joint_2_type" value="revolute" />
-    <xacro:property name="joint_2_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_2_origin_xyz" value="0 0.0016 -0.11875" />
-    <xacro:property name="joint_2_origin_rpy" value="-${J_PI/2} 0 ${J_PI}" />
-    <xacro:property name="joint_2_lower_limit" value="${47/180*J_PI}" />
-    <xacro:property name="joint_2_upper_limit" value="${313/180*J_PI}" />
-    <xacro:property name="joint_2_velocity_limit" value="${36*J_PI/180}" />
-    <xacro:property name="joint_2_torque_limit" value="80" />
+  <xacro:property
+    name="joint_2"
+    value="joint_2"
+  />
+  <xacro:property
+    name="joint_2_type"
+    value="revolute"
+  />
+  <xacro:property
+    name="joint_2_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_2_origin_xyz"
+    value="0 0.0016 -0.11875"
+  />
+  <xacro:property
+    name="joint_2_origin_rpy"
+    value="-${J_PI/2} 0 ${J_PI}"
+  />
+  <xacro:property
+    name="joint_2_lower_limit"
+    value="${47/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_2_upper_limit"
+    value="${313/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_2_velocity_limit"
+    value="${36*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_2_torque_limit"
+    value="80"
+  />
 
-    <xacro:property name="joint_3" value="joint_3" />
-    <xacro:property name="joint_3_type" value="continuous" />
-    <xacro:property name="joint_3_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_3_origin_xyz" value="0 -0.205 0" />
-    <xacro:property name="joint_3_origin_rpy" value="-${J_PI/2} 0 0" />
-    <xacro:property name="joint_3_lower_limit" value="${-2*J_PI}" />
-    <xacro:property name="joint_3_upper_limit" value="${2*J_PI}" />
-    <xacro:property name="joint_3_velocity_limit" value="${36*J_PI/180}" />
-    <xacro:property name="joint_3_torque_limit" value="40" />
+  <xacro:property
+    name="joint_3"
+    value="joint_3"
+  />
+  <xacro:property
+    name="joint_3_type"
+    value="continuous"
+  />
+  <xacro:property
+    name="joint_3_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_3_origin_xyz"
+    value="0 -0.205 0"
+  />
+  <xacro:property
+    name="joint_3_origin_rpy"
+    value="-${J_PI/2} 0 0"
+  />
+  <xacro:property
+    name="joint_3_lower_limit"
+    value="${-2*J_PI}"
+  />
+  <xacro:property
+    name="joint_3_upper_limit"
+    value="${2*J_PI}"
+  />
+  <xacro:property
+    name="joint_3_velocity_limit"
+    value="${36*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_3_torque_limit"
+    value="40"
+  />
 
-    <xacro:property name="joint_4" value="joint_4" />
-    <xacro:property name="joint_4_type" value="revolute" />
-    <xacro:property name="joint_4_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_4_origin_xyz" value="0 0 -0.205" />
-    <xacro:property name="joint_4_origin_rpy" value="${J_PI/2} 0 ${J_PI}"/>
-    <xacro:property name="joint_4_lower_limit" value="${30/180*J_PI}" />
-    <xacro:property name="joint_4_upper_limit" value="${330/180*J_PI}" />
-    <xacro:property name="joint_4_velocity_limit" value="${36*J_PI/180}" />
-    <xacro:property name="joint_4_torque_limit" value="40" />
+  <xacro:property
+    name="joint_4"
+    value="joint_4"
+  />
+  <xacro:property
+    name="joint_4_type"
+    value="revolute"
+  />
+  <xacro:property
+    name="joint_4_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_4_origin_xyz"
+    value="0 0 -0.205"
+  />
+  <xacro:property
+    name="joint_4_origin_rpy"
+    value="${J_PI/2} 0 ${J_PI}"
+  />
+  <xacro:property
+    name="joint_4_lower_limit"
+    value="${30/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_4_upper_limit"
+    value="${330/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_4_velocity_limit"
+    value="${36*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_4_torque_limit"
+    value="40"
+  />
 
-    <xacro:property name="joint_5" value="joint_5" />
-    <xacro:property name="joint_5_type" value="continuous" />
-    <xacro:property name="joint_5_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_5_origin_xyz" value="0 0.2073 -0.0114" />
-    <xacro:property name="joint_5_origin_rpy" value="${-J_PI/2} 0 ${J_PI}" />
-    <xacro:property name="joint_5_lower_limit" value="${-2*J_PI}" />
-    <xacro:property name="joint_5_upper_limit" value="${2*J_PI}" />
-    <xacro:property name="joint_5_velocity_limit" value="${48*J_PI/180}" />
-    <xacro:property name="joint_5_torque_limit" value="20" />
+  <xacro:property
+    name="joint_5"
+    value="joint_5"
+  />
+  <xacro:property
+    name="joint_5_type"
+    value="continuous"
+  />
+  <xacro:property
+    name="joint_5_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_5_origin_xyz"
+    value="0 0.2073 -0.0114"
+  />
+  <xacro:property
+    name="joint_5_origin_rpy"
+    value="${-J_PI/2} 0 ${J_PI}"
+  />
+  <xacro:property
+    name="joint_5_lower_limit"
+    value="${-2*J_PI}"
+  />
+  <xacro:property
+    name="joint_5_upper_limit"
+    value="${2*J_PI}"
+  />
+  <xacro:property
+    name="joint_5_velocity_limit"
+    value="${48*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_5_torque_limit"
+    value="20"
+  />
 
-    <xacro:property name="joint_6" value="joint_6" />
-    <xacro:property name="joint_6_type" value="revolute" />
-    <xacro:property name="joint_6_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_6_origin_xyz" value="0 0 -0.10375" />
-    <xacro:property name="joint_6_origin_rpy" value="${J_PI/2} 0 ${J_PI}" />
-    <xacro:property name="joint_6_lower_limit" value="${65/180*J_PI}" />
-    <xacro:property name="joint_6_upper_limit" value="${295/180*J_PI}" />
-    <xacro:property name="joint_6_velocity_limit" value="${48*J_PI/180}" />
-    <xacro:property name="joint_6_torque_limit" value="20" />
+  <xacro:property
+    name="joint_6"
+    value="joint_6"
+  />
+  <xacro:property
+    name="joint_6_type"
+    value="revolute"
+  />
+  <xacro:property
+    name="joint_6_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_6_origin_xyz"
+    value="0 0 -0.10375"
+  />
+  <xacro:property
+    name="joint_6_origin_rpy"
+    value="${J_PI/2} 0 ${J_PI}"
+  />
+  <xacro:property
+    name="joint_6_lower_limit"
+    value="${65/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_6_upper_limit"
+    value="${295/180*J_PI}"
+  />
+  <xacro:property
+    name="joint_6_velocity_limit"
+    value="${48*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_6_torque_limit"
+    value="20"
+  />
 
-    <xacro:property name="joint_7" value="joint_7" />
-    <xacro:property name="joint_7_type" value="continuous" />
-    <xacro:property name="joint_7_axis_xyz" value="0 0 1" />
-    <xacro:property name="joint_7_origin_xyz" value="0 0.10375 0" />
-    <xacro:property name="joint_7_origin_rpy" value="${-J_PI/2} 0 ${J_PI}" />
-    <xacro:property name="joint_7_lower_limit" value="${-2*J_PI}" />
-    <xacro:property name="joint_7_upper_limit" value="${2*J_PI}" />
-    <xacro:property name="joint_7_velocity_limit" value="${48*J_PI/180}" />
-    <xacro:property name="joint_7_torque_limit" value="20" />
+  <xacro:property
+    name="joint_7"
+    value="joint_7"
+  />
+  <xacro:property
+    name="joint_7_type"
+    value="continuous"
+  />
+  <xacro:property
+    name="joint_7_axis_xyz"
+    value="0 0 1"
+  />
+  <xacro:property
+    name="joint_7_origin_xyz"
+    value="0 0.10375 0"
+  />
+  <xacro:property
+    name="joint_7_origin_rpy"
+    value="${-J_PI/2} 0 ${J_PI}"
+  />
+  <xacro:property
+    name="joint_7_lower_limit"
+    value="${-2*J_PI}"
+  />
+  <xacro:property
+    name="joint_7_upper_limit"
+    value="${2*J_PI}"
+  />
+  <xacro:property
+    name="joint_7_velocity_limit"
+    value="${48*J_PI/180}"
+  />
+  <xacro:property
+    name="joint_7_torque_limit"
+    value="20"
+  />
 
-    <xacro:property name="joint_end_effector" value="end_effector_offset" />
-    <xacro:property name="joint_end_effector_type" value="fixed" />
-    <xacro:property name="joint_end_effector_axis_xyz" value="0 0 0" />
-    <xacro:property name="joint_end_effector_origin_xyz" value="0 0 -0.1600" />
-    <xacro:property name="joint_end_effector_origin_rpy" value="${J_PI} 0 ${J_PI/2}" />
+  <xacro:property
+    name="joint_end_effector"
+    value="end_effector_offset"
+  />
+  <xacro:property
+    name="joint_end_effector_type"
+    value="fixed"
+  />
+  <xacro:property
+    name="joint_end_effector_axis_xyz"
+    value="0 0 0"
+  />
+  <xacro:property
+    name="joint_end_effector_origin_xyz"
+    value="0 0 -0.1600"
+  />
+  <xacro:property
+    name="joint_end_effector_origin_rpy"
+    value="${J_PI} 0 ${J_PI/2}"
+  />
 
+  <xacro:macro
+    name="j2s7s300"
+    params="base_parent prefix:=j2s7s300"
+  >
+    <xacro:gazebo_config robot_namespace="${prefix}"/>
 
-    <xacro:macro name="j2s7s300" params="base_parent prefix:=j2s7s300">
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_base"
+      link_mesh="${link_base_mesh}"
+      mesh_no="${link_base_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_base"
+      type="${joint_base_type}"
+      parent="${base_parent}"
+      child="${prefix}_link_base"
+      joint_axis_xyz="${joint_base_axis_xyz}"
+      joint_origin_xyz="${joint_base_origin_xyz}"
+      joint_origin_rpy="${joint_base_origin_rpy}"
+      joint_lower_limit="0"
+      joint_upper_limit="0"
+      joint_velocity_limit="0"
+      joint_torque_limit="0"
+      fixed="true"
+    />
 
-        <xacro:gazebo_config robot_namespace="${prefix}"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_1"
+      link_mesh="${link_1_mesh}"
+      use_ring_mesh="true"
+      mesh_no="${link_1_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_1"
+      type="${joint_1_type}"
+      parent="${prefix}_link_base"
+      child="${prefix}_link_1"
+      joint_axis_xyz="${joint_1_axis_xyz}"
+      joint_origin_xyz="${joint_1_origin_xyz}"
+      joint_origin_rpy="${joint_1_origin_rpy}"
+      joint_lower_limit="${joint_1_lower_limit}"
+      joint_upper_limit="${joint_1_upper_limit}"
+      joint_velocity_limit="${joint_1_velocity_limit}"
+      joint_torque_limit="${joint_1_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_base" link_mesh="${link_base_mesh}" mesh_no="${link_base_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_base" type="${joint_base_type}" parent="${base_parent}" child="${prefix}_link_base" joint_axis_xyz="${joint_base_axis_xyz}" joint_origin_xyz="${joint_base_origin_xyz}" joint_origin_rpy="${joint_base_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0" joint_velocity_limit="0" joint_torque_limit="0" fixed="true"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_2"
+      link_mesh="${link_2_mesh}"
+      use_ring_mesh="true"
+      mesh_no="${link_2_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_2"
+      type="${joint_2_type}"
+      parent="${prefix}_link_1"
+      child="${prefix}_link_2"
+      joint_axis_xyz="${joint_2_axis_xyz}"
+      joint_origin_xyz="${joint_2_origin_xyz}"
+      joint_origin_rpy="${joint_2_origin_rpy}"
+      joint_lower_limit="${joint_2_lower_limit}"
+      joint_upper_limit="${joint_2_upper_limit}"
+      joint_velocity_limit="${joint_2_velocity_limit}"
+      joint_torque_limit="${joint_2_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_1" link_mesh="${link_1_mesh}" use_ring_mesh="true" mesh_no="${link_1_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_1" type="${joint_1_type}" parent="${prefix}_link_base" child="${prefix}_link_1" joint_axis_xyz="${joint_1_axis_xyz}" joint_origin_xyz="${joint_1_origin_xyz}" joint_origin_rpy="${joint_1_origin_rpy}" joint_lower_limit="${joint_1_lower_limit}" joint_upper_limit="${joint_1_upper_limit}" joint_velocity_limit="${joint_1_velocity_limit}" joint_torque_limit="${joint_1_torque_limit}"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_3"
+      link_mesh="${link_3_mesh}"
+      use_ring_mesh="true"
+      mesh_no="${link_3_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_3"
+      type="${joint_3_type}"
+      parent="${prefix}_link_2"
+      child="${prefix}_link_3"
+      joint_axis_xyz="${joint_3_axis_xyz}"
+      joint_origin_xyz="${joint_3_origin_xyz}"
+      joint_origin_rpy="${joint_3_origin_rpy}"
+      joint_lower_limit="${joint_3_lower_limit}"
+      joint_upper_limit="${joint_3_upper_limit}"
+      joint_velocity_limit="${joint_3_velocity_limit}"
+      joint_torque_limit="${joint_3_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_2" link_mesh="${link_2_mesh}" use_ring_mesh="true" mesh_no="${link_2_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_2" type="${joint_2_type}" parent="${prefix}_link_1" child="${prefix}_link_2" joint_axis_xyz="${joint_2_axis_xyz}" joint_origin_xyz="${joint_2_origin_xyz}" joint_origin_rpy="${joint_2_origin_rpy}" joint_lower_limit="${joint_2_lower_limit}" joint_upper_limit="${joint_2_upper_limit}" joint_velocity_limit="${joint_2_velocity_limit}" joint_torque_limit="${joint_2_torque_limit}"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_4"
+      link_mesh="${link_4_mesh}"
+      use_ring_mesh="true"
+      mesh_no="${link_4_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_4"
+      type="${joint_4_type}"
+      parent="${prefix}_link_3"
+      child="${prefix}_link_4"
+      joint_axis_xyz="${joint_4_axis_xyz}"
+      joint_origin_xyz="${joint_4_origin_xyz}"
+      joint_origin_rpy="${joint_4_origin_rpy}"
+      joint_lower_limit="${joint_4_lower_limit}"
+      joint_upper_limit="${joint_4_upper_limit}"
+      joint_velocity_limit="${joint_4_velocity_limit}"
+      joint_torque_limit="${joint_4_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_3" link_mesh="${link_3_mesh}" use_ring_mesh="true" mesh_no="${link_3_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_3" type="${joint_3_type}" parent="${prefix}_link_2" child="${prefix}_link_3" joint_axis_xyz="${joint_3_axis_xyz}" joint_origin_xyz="${joint_3_origin_xyz}" joint_origin_rpy="${joint_3_origin_rpy}" joint_lower_limit="${joint_3_lower_limit}" joint_upper_limit="${joint_3_upper_limit}" joint_velocity_limit="${joint_3_velocity_limit}" joint_torque_limit="${joint_3_torque_limit}"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_5"
+      link_mesh="${link_5_mesh}"
+      use_ring_mesh="true"
+      ring_mesh="ring_small"
+      mesh_no="${link_5_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_5"
+      type="${joint_5_type}"
+      parent="${prefix}_link_4"
+      child="${prefix}_link_5"
+      joint_axis_xyz="${joint_5_axis_xyz}"
+      joint_origin_xyz="${joint_5_origin_xyz}"
+      joint_origin_rpy="${joint_5_origin_rpy}"
+      joint_lower_limit="${joint_5_lower_limit}"
+      joint_upper_limit="${joint_5_upper_limit}"
+      joint_velocity_limit="${joint_5_velocity_limit}"
+      joint_torque_limit="${joint_5_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_4" link_mesh="${link_4_mesh}" use_ring_mesh="true" mesh_no="${link_4_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_4" type="${joint_4_type}" parent="${prefix}_link_3" child="${prefix}_link_4" joint_axis_xyz="${joint_4_axis_xyz}" joint_origin_xyz="${joint_4_origin_xyz}" joint_origin_rpy="${joint_4_origin_rpy}" joint_lower_limit="${joint_4_lower_limit}" joint_upper_limit="${joint_4_upper_limit}" joint_velocity_limit="${joint_4_velocity_limit}" joint_torque_limit="${joint_4_torque_limit}"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_6"
+      link_mesh="${link_6_mesh}"
+      use_ring_mesh="true"
+      ring_mesh="ring_small"
+      mesh_no="${link_6_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_6"
+      type="${joint_6_type}"
+      parent="${prefix}_link_5"
+      child="${prefix}_link_6"
+      joint_axis_xyz="${joint_6_axis_xyz}"
+      joint_origin_xyz="${joint_6_origin_xyz}"
+      joint_origin_rpy="${joint_6_origin_rpy}"
+      joint_lower_limit="${joint_6_lower_limit}"
+      joint_upper_limit="${joint_6_upper_limit}"
+      joint_velocity_limit="${joint_6_velocity_limit}"
+      joint_torque_limit="${joint_6_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_5" link_mesh="${link_5_mesh}" use_ring_mesh="true" ring_mesh="ring_small" mesh_no="${link_5_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_5" type="${joint_5_type}" parent="${prefix}_link_4" child="${prefix}_link_5" joint_axis_xyz="${joint_5_axis_xyz}" joint_origin_xyz="${joint_5_origin_xyz}" joint_origin_rpy="${joint_5_origin_rpy}" joint_lower_limit="${joint_5_lower_limit}" joint_upper_limit="${joint_5_upper_limit}" joint_velocity_limit="${joint_5_velocity_limit}" joint_torque_limit="${joint_5_torque_limit}"/>
+    <xacro:kinova_armlink
+      link_name="${prefix}_link_7"
+      link_mesh="${link_7_mesh}"
+      use_ring_mesh="true"
+      ring_mesh="ring_small"
+      mesh_no="${link_7_mesh_no}"
+    />
+    <xacro:kinova_armjoint
+      joint_name="${prefix}_joint_7"
+      type="${joint_7_type}"
+      parent="${prefix}_link_6"
+      child="${prefix}_link_7"
+      joint_axis_xyz="${joint_7_axis_xyz}"
+      joint_origin_xyz="${joint_7_origin_xyz}"
+      joint_origin_rpy="${joint_7_origin_rpy}"
+      joint_lower_limit="${joint_7_lower_limit}"
+      joint_upper_limit="${joint_7_upper_limit}"
+      joint_velocity_limit="${joint_7_velocity_limit}"
+      joint_torque_limit="${joint_7_torque_limit}"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_6" link_mesh="${link_6_mesh}" use_ring_mesh="true" ring_mesh="ring_small" mesh_no="${link_6_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_6" type="${joint_6_type}" parent="${prefix}_link_5" child="${prefix}_link_6" joint_axis_xyz="${joint_6_axis_xyz}" joint_origin_xyz="${joint_6_origin_xyz}" joint_origin_rpy="${joint_6_origin_rpy}" joint_lower_limit="${joint_6_lower_limit}" joint_upper_limit="${joint_6_upper_limit}" joint_velocity_limit="${joint_6_velocity_limit}" joint_torque_limit="${joint_6_torque_limit}"/>
+    <xacro:kinova_virtual_link link_name="${prefix}_end_effector"/>
+    <xacro:kinova_virtual_joint
+      joint_name="${prefix}_joint_end_effector"
+      type="${joint_end_effector_type}"
+      parent="${prefix}_link_7"
+      child="${prefix}_end_effector"
+      joint_axis_xyz="${joint_end_effector_axis_xyz}"
+      joint_origin_xyz="${joint_end_effector_origin_xyz}"
+      joint_origin_rpy="${joint_end_effector_origin_rpy}"
+      joint_lower_limit="0"
+      joint_upper_limit="0"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}_link_7" link_mesh="${link_7_mesh}" use_ring_mesh="true" ring_mesh="ring_small" mesh_no="${link_7_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_7" type="${joint_7_type}" parent="${prefix}_link_6" child="${prefix}_link_7" joint_axis_xyz="${joint_7_axis_xyz}" joint_origin_xyz="${joint_7_origin_xyz}" joint_origin_rpy="${joint_7_origin_rpy}" joint_lower_limit="${joint_7_lower_limit}" joint_upper_limit="${joint_7_upper_limit}" joint_velocity_limit="${joint_7_velocity_limit}" joint_torque_limit="${joint_7_torque_limit}"/>
-
-        <xacro:kinova_virtual_link link_name="${prefix}_end_effector"/>
-        <xacro:kinova_virtual_joint joint_name="${prefix}_joint_end_effector" type="${joint_end_effector_type}" parent="${prefix}_link_7" child="${prefix}_end_effector" joint_axis_xyz="${joint_end_effector_axis_xyz}" joint_origin_xyz="${joint_end_effector_origin_xyz}" joint_origin_rpy="${joint_end_effector_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0"/>
-
-        <xacro:kinova_3fingers link_hand="${prefix}_link_7" prefix="${prefix}_"/>
-    </xacro:macro>
-
-
-
-
+    <xacro:kinova_3fingers
+      link_hand="${prefix}_link_7"
+      prefix="${prefix}_"
+    />
+  </xacro:macro>
 </root>

--- a/ada_description/urdf/j2s7s300_standalone.xacro
+++ b/ada_description/urdf/j2s7s300_standalone.xacro
@@ -1,22 +1,21 @@
 <?xml version="1.0"?>
 <!-- j2s7s300 refers to jaco v2 7DOF spherical 3fingers -->
-
-
-<robot xmlns:xi="http://www.w3.org/2001/XInclude"
-	xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
-    xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
-	xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-	xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
-    xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
-    xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
-	xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-	xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
-	xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
-    xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
-    xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-	xmlns:xacro="http://www.ros.org/wiki/xacro" name="j2s7s300">
-
-
+<robot
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
+  xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
+  xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+  xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
+  xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
+  xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
+  xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+  xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+  xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
+  xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
+  xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
+  xmlns:xacro="http://www.ros.org/wiki/xacro"
+  name="j2s7s300"
+>
   <xacro:include filename="$(find ada_description)/urdf/j2s7s300.xacro"/>
 
   <link name="root"/>
@@ -24,14 +23,22 @@
   <!-- for gazebo -->
   <link name="world"/>
 
-  <joint name="connect_root_and_world" type="fixed">
-    <child link="root" />
-    <parent link="world" />
-    <origin xyz="0 0 0" rpy="0 0 0" />
+  <joint
+    name="connect_root_and_world"
+    type="fixed"
+  >
+    <child link="root"/>
+    <parent link="world"/>
+    <origin
+      xyz="0 0 0"
+      rpy="0 0 0"
+    />
   </joint>
 
-  <xacro:property name="robot_root" value="root" />
+  <xacro:property
+    name="robot_root"
+    value="root"
+  />
 
-  <xacro:j2s7s300  base_parent="${robot_root}"/>
-
+  <xacro:j2s7s300 base_parent="${robot_root}"/>
 </robot>

--- a/ada_description/urdf/kinova_common.xacro
+++ b/ada_description/urdf/kinova_common.xacro
@@ -1,57 +1,57 @@
 <?xml version="1.0"?>
+<root
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
+  xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
+  xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+  xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
+  xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
+  xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
+  xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+  xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+  xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
+  xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
+  xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
+  xmlns:xacro="http://www.ros.org/wiki/xacro"
+>
+  <xacro:include filename="$(find ada_description)/urdf/kinova_inertial.xacro"/>
 
+  <xacro:property
+    name="J_PI"
+    value="3.1415926535897931"
+  />
 
-<root xmlns:xi="http://www.w3.org/2001/XInclude"
-	xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
-    xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
-	xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-	xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
-    xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
-    xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
-	xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-	xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
-	xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
-    xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
-    xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-	xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:macro
+    name="kinova_armlink"
+    params="link_name link_mesh ring_mesh:=ring_big use_ring_mesh:=false mesh_no"
+  >
+    <link name="${link_name}">
+      <visual>
+        <geometry>
+          <mesh filename="package://ada_description/meshes/${link_mesh}.dae"/>
+        </geometry>
+        <material name="carbon_fiber">
+          <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+        </material>
+      </visual>
 
-<xacro:include filename="$(find ada_description)/urdf/kinova_inertial.xacro" />
+      <!-- Adding ring to the model -->
+      <xacro:if value="${use_ring_mesh}">
+        <visual>
+          <geometry>
+            <mesh filename="package://ada_description/meshes/${ring_mesh}.dae"/>
+          </geometry>
+        </visual>
+      </xacro:if>
 
-
-    <xacro:property name="J_PI" value="3.1415926535897931" />
-
-    <xacro:macro name="kinova_armlink" params="link_name link_mesh ring_mesh:=ring_big use_ring_mesh:=false mesh_no">
-        <link name="${link_name}">
-            <visual>
-                <geometry>
-                    <mesh
-                        filename="package://ada_description/meshes/${link_mesh}.dae"/>
-                </geometry>
-                <material name="carbon_fiber">
-                    <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1" />
-                </material>
-            </visual>
-
-	    <!-- Adding ring to the model -->
-	         <xacro:if value="${use_ring_mesh}">
-	           <visual>
-                <geometry>
-                    <mesh
-                        filename="package://ada_description/meshes/${ring_mesh}.dae"/>
-                </geometry>
-             </visual>
-	    </xacro:if>
-
-            <collision>
-                <geometry>
-                    <mesh
-                        filename="package://ada_description/meshes/${link_mesh}.dae"/>
-                </geometry>
-            </collision>
-						<xacro:kinova_inertial mesh_no="${mesh_no}"/>
-      </link>
-
-    </xacro:macro>
+      <collision>
+        <geometry>
+          <mesh filename="package://ada_description/meshes/${link_mesh}.dae"/>
+        </geometry>
+      </collision>
+      <xacro:kinova_inertial mesh_no="${mesh_no}"/>
+    </link>
+  </xacro:macro>
 
   <!--
     We use dummy default values for values only required when type=='revolute':
@@ -61,8 +61,13 @@
     Similarly, we check that velocity and torque limits are set unless the joint
     type is fixed, and that the fixed parameter is set consistently.
   -->
-  <xacro:property name="dummy_default_value" value="1234567890"/>
-  <xacro:macro name="kinova_armjoint" params="joint_name
+  <xacro:property
+    name="dummy_default_value"
+    value="1234567890"
+  />
+  <xacro:macro
+    name="kinova_armjoint"
+    params="joint_name
                                               type
                                               parent
                                               child
@@ -73,117 +78,190 @@
                                               joint_upper_limit:=${dummy_default_value}
                                               joint_velocity_limit:=${dummy_default_value}
                                               joint_torque_limit:=${dummy_default_value}
-                                              fixed:=false">
-    <xacro:if value="${(type == 'fixed' and not fixed) or (type != 'fixed' and fixed)}"><xacro:ERROR_inconsistent_joint_type_specification/></xacro:if>
+                                              fixed:=false"
+  >
+    <xacro:if value="${(type == 'fixed' and not fixed) or (type != 'fixed' and fixed)}">
+      <xacro:ERROR_inconsistent_joint_type_specification/>
+    </xacro:if>
     <xacro:if value="${type == 'revolute'}">
-      <xacro:if value="${joint_lower_limit == dummy_default_value}"><xacro:ERROR_joint_lower_limit_needs_to_be_set_for_a_revolute_joint/></xacro:if>
-      <xacro:if value="${joint_upper_limit == dummy_default_value}"><xacro:ERROR_joint_upper_limit_needs_to_be_set_for_a_revolute_joint/></xacro:if>
+      <xacro:if value="${joint_lower_limit == dummy_default_value}">
+        <xacro:ERROR_joint_lower_limit_needs_to_be_set_for_a_revolute_joint/>
+      </xacro:if>
+      <xacro:if value="${joint_upper_limit == dummy_default_value}">
+        <xacro:ERROR_joint_upper_limit_needs_to_be_set_for_a_revolute_joint/>
+      </xacro:if>
     </xacro:if>
     <xacro:unless value="${type =='fixed'}">
-      <xacro:if value="${joint_velocity_limit == dummy_default_value}"><xacro:ERROR_joint_velocity_limit_needs_to_be_set_for_a_non_fixed_joint/></xacro:if>
-      <xacro:if value="${joint_torque_limit == dummy_default_value}"><xacro:ERROR_joint_torque_limit_needs_to_be_set_for_a_non_fixed_joint/></xacro:if>
+      <xacro:if value="${joint_velocity_limit == dummy_default_value}">
+        <xacro:ERROR_joint_velocity_limit_needs_to_be_set_for_a_non_fixed_joint/>
+      </xacro:if>
+      <xacro:if value="${joint_torque_limit == dummy_default_value}">
+        <xacro:ERROR_joint_torque_limit_needs_to_be_set_for_a_non_fixed_joint/>
+      </xacro:if>
     </xacro:unless>
-    <joint name="${joint_name}" type="${type}">
-        <parent link="${parent}"/>
-        <child link="${child}"/>
-        <axis xyz="${joint_axis_xyz}"/>
-        <xacro:if value="${type == 'revolute'}">
-        <limit effort="${joint_torque_limit}" velocity="${joint_velocity_limit}" lower="${joint_lower_limit}" upper="${joint_upper_limit}"/>
-        </xacro:if>
-        <xacro:if value="${type == 'continuous'}">
-        <limit effort="${joint_torque_limit}" velocity="${joint_velocity_limit}"/>
-        </xacro:if>
-        <origin xyz="${joint_origin_xyz}" rpy="${joint_origin_rpy}"/>
-        <dynamics damping="0.0" friction="0.0"/>
-     </joint>
-   <xacro:unless value="${fixed}">
-     <transmission name="${joint_name}_trans">
+    <joint
+      name="${joint_name}"
+      type="${type}"
+    >
+      <parent link="${parent}"/>
+      <child link="${child}"/>
+      <axis xyz="${joint_axis_xyz}"/>
+      <xacro:if value="${type == 'revolute'}">
+        <limit
+          effort="${joint_torque_limit}"
+          velocity="${joint_velocity_limit}"
+          lower="${joint_lower_limit}"
+          upper="${joint_upper_limit}"
+        />
+      </xacro:if>
+      <xacro:if value="${type == 'continuous'}">
+        <limit
+          effort="${joint_torque_limit}"
+          velocity="${joint_velocity_limit}"
+        />
+      </xacro:if>
+      <origin
+        xyz="${joint_origin_xyz}"
+        rpy="${joint_origin_rpy}"
+      />
+      <dynamics
+        damping="0.0"
+        friction="0.0"
+      />
+    </joint>
+    <xacro:unless value="${fixed}">
+      <transmission name="${joint_name}_trans">
         <type>transmission_interface/SimpleTransmission</type>
         <joint name="${joint_name}">
           <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
         </joint>
         <actuator name="${joint_name}_actuator">
           <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
-        <mechanicalReduction>160</mechanicalReduction>
+          <mechanicalReduction>160</mechanicalReduction>
         </actuator>
-     </transmission>
-     <!--For torque sensing in simulation-->
-     <gazebo reference="${joint_name}">
+      </transmission>
+      <!--For torque sensing in simulation-->
+      <gazebo reference="${joint_name}">
         <provideFeedback>true</provideFeedback>
       </gazebo>
       <gazebo>
-        <plugin name="ft_sensor" filename="libgazebo_ros_ft_sensor.so">
+        <plugin
+          name="ft_sensor"
+          filename="libgazebo_ros_ft_sensor.so"
+        >
           <updateRate>30.0</updateRate>
           <topicName>${joint_name}_ft_sensor_topic</topicName>
           <jointName>${joint_name}</jointName>
         </plugin>
       </gazebo>
-     </xacro:unless>
+    </xacro:unless>
   </xacro:macro>
 
+  <xacro:macro
+    name="kinova_virtual_link"
+    params="link_name"
+  >
+    <link name="${link_name}"/>
+  </xacro:macro>
 
-    <xacro:macro name="kinova_virtual_link" params="link_name">
-        <link name="${link_name}"/>
-    </xacro:macro>
+  <xacro:macro
+    name="kinova_virtual_joint"
+    params="joint_name type parent child joint_axis_xyz joint_origin_xyz joint_origin_rpy joint_lower_limit joint_upper_limit"
+  >
+    <joint
+      name="${joint_name}"
+      type="${type}"
+    >
+      <parent link="${parent}"/>
+      <child link="${child}"/>
+      <axis xyz="${joint_axis_xyz}"/>
+      <xacro:unless value="${type == 'fixed'}">
+        <limit
+          effort="2000"
+          velocity="1"
+          lower="${joint_lower_limit}"
+          upper="${joint_upper_limit}"
+        />
+      </xacro:unless>
+      <origin
+        xyz="${joint_origin_xyz}"
+        rpy="${joint_origin_rpy}"
+      />
+    </joint>
+  </xacro:macro>
 
-    <xacro:macro name="kinova_virtual_joint" params="joint_name type parent child joint_axis_xyz joint_origin_xyz joint_origin_rpy joint_lower_limit joint_upper_limit">
-    <joint name="${joint_name}" type="${type}">
-        <parent link="${parent}"/>
-        <child link="${child}"/>
-        <axis xyz="${joint_axis_xyz}"/>
-        <xacro:unless value="${type == 'fixed'}">
-        <limit effort="2000" velocity="1" lower="${joint_lower_limit}" upper="${joint_upper_limit}"/>
-        </xacro:unless>
-        <origin xyz="${joint_origin_xyz}" rpy="${joint_origin_rpy}"/>
-     </joint>
-    </xacro:macro>
+  <xacro:macro
+    name="kinova_finger"
+    params="prefix finger_number hand finger_origin_xyz finger_origin_rpy"
+  >
+    <xacro:kinova_armlink
+      link_name="${prefix}link_finger_${finger_number}"
+      link_mesh="finger_proximal"
+      mesh_no="57"
+    />
 
+    <joint
+      name="${prefix}joint_finger_${finger_number}"
+      type="revolute"
+    >
+      <parent link="${hand}"/>
+      <child link="${prefix}link_finger_${finger_number}"/>
+      <axis xyz="0 0 1"/>
+      <origin
+        xyz="${finger_origin_xyz}"
+        rpy="${finger_origin_rpy}"
+      />
+      <limit
+        lower="0"
+        upper="1.51"
+        effort="2"
+        velocity="1"
+      />
+    </joint>
+    <transmission name="${prefix}joint_finger_${finger_number}_trans">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${prefix}joint_finger_${finger_number}">
+        <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${prefix}joint_finger_${finger_number}_actuator">
+        <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
 
-    <xacro:macro name="kinova_finger" params="prefix finger_number hand finger_origin_xyz finger_origin_rpy">
+    <xacro:kinova_armlink
+      link_name="${prefix}link_finger_tip_${finger_number}"
+      link_mesh="finger_distal"
+      mesh_no="58"
+    />
 
-        <xacro:kinova_armlink link_name="${prefix}link_finger_${finger_number}" link_mesh="finger_proximal" mesh_no="57"/>
-
-        <joint name="${prefix}joint_finger_${finger_number}" type="revolute">
-            <parent link="${hand}"/>
-            <child link="${prefix}link_finger_${finger_number}"/>
-            <axis xyz="0 0 1"/>
-            <origin xyz="${finger_origin_xyz}" rpy="${finger_origin_rpy}"/>
-            <limit lower="0" upper="1.51" effort="2" velocity="1"/>
-        </joint>
-		    <transmission name="${prefix}joint_finger_${finger_number}_trans">
-					<type>transmission_interface/SimpleTransmission</type>
-					<joint name="${prefix}joint_finger_${finger_number}">
-					  <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
-					</joint>
-					<actuator name="${prefix}joint_finger_${finger_number}_actuator">
-					<hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
-					<mechanicalReduction>1</mechanicalReduction>
-					</actuator>
-		    </transmission>
-
-
-
-        <xacro:kinova_armlink link_name="${prefix}link_finger_tip_${finger_number}" link_mesh="finger_distal" mesh_no="58"/>
-
-        <joint name="${prefix}joint_finger_tip_${finger_number}" type="fixed">
-            <parent link="${prefix}link_finger_${finger_number}"/>
-            <child link="${prefix}link_finger_tip_${finger_number}"/>
-            <axis xyz="0 0 1"/>
-            <origin xyz="0.044 -0.003 0" rpy="0 0 0"/>
-            <limit lower="0" upper="2" effort="2" velocity="1"/>
-        </joint>
-        <transmission name="${prefix}joint_finger_tip_${finger_number}_trans">
-					<type>transmission_interface/SimpleTransmission</type>
-					<joint name="${prefix}joint_finger_tip_${finger_number}">
-					  <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
-					</joint>
-					<actuator name="${prefix}joint_finger_tip_${finger_number}_actuator">
-					<hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
-					<mechanicalReduction>1</mechanicalReduction>
-					</actuator>
-        </transmission>
-
-    </xacro:macro>
-
-
+    <joint
+      name="${prefix}joint_finger_tip_${finger_number}"
+      type="fixed"
+    >
+      <parent link="${prefix}link_finger_${finger_number}"/>
+      <child link="${prefix}link_finger_tip_${finger_number}"/>
+      <axis xyz="0 0 1"/>
+      <origin
+        xyz="0.044 -0.003 0"
+        rpy="0 0 0"
+      />
+      <limit
+        lower="0"
+        upper="2"
+        effort="2"
+        velocity="1"
+      />
+    </joint>
+    <transmission name="${prefix}joint_finger_tip_${finger_number}_trans">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${prefix}joint_finger_tip_${finger_number}">
+        <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="${prefix}joint_finger_tip_${finger_number}_actuator">
+        <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+  </xacro:macro>
 </root>

--- a/ada_description/urdf/kinova_finger_set.xacro
+++ b/ada_description/urdf/kinova_finger_set.xacro
@@ -1,45 +1,71 @@
 <?xml version="1.0"?>
 <!-- for 3finger_hand and 2finger_hand -->
+<root
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
+  xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
+  xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+  xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
+  xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
+  xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
+  xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+  xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+  xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
+  xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
+  xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
+  xmlns:xacro="http://www.ros.org/wiki/xacro"
+>
+  <xacro:include filename="$(find ada_description)/urdf/kinova_common.xacro"/>
 
+  <xacro:macro
+    name="kinova_3fingers"
+    params="link_hand prefix"
+  >
+    <!-- finger1 Rot := Ry(96.12*((1/180)*Pi)) . Rx(1.2*((1/180)*Pi)) . Rz(52.52*((1/180)*Pi)) -->
+    <xacro:kinova_finger
+      prefix="${prefix}"
+      finger_number="1"
+      hand="${link_hand}"
+      finger_origin_xyz="0.00279 0.03126 -0.11467"
+      finger_origin_rpy="-1.7047873384941834 0.6476144647144773 1.67317415161155"
+    />
+    <!-- finger2 Rot := Ry((1/2)*Pi) . Rx(10.58*((1/180)*Pi)) . Rz(-52.8*((1/180)*Pi)) -->
+    <xacro:kinova_finger
+      prefix="${prefix}"
+      finger_number="2"
+      hand="${link_hand}"
+      finger_origin_xyz="0.02226 -0.02707 -0.11482"
+      finger_origin_rpy="-1.570796327 .649262481663582 -1.38614049188413"
+    />
+    <!-- finger3 Rot := Ry((1/2)*Pi) . Rx(-10.58*((1/180)*Pi)) . Rz(-52.8*((1/180)*Pi)) -->
+    <xacro:kinova_finger
+      prefix="${prefix}"
+      finger_number="3"
+      hand="${link_hand}"
+      finger_origin_xyz="-0.02226 -0.02707 -0.11482"
+      finger_origin_rpy="-1.570796327 .649262481663582 -1.75545216211587"
+    />
+  </xacro:macro>
 
-<root xmlns:xi="http://www.w3.org/2001/XInclude"
-    xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
-    xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
-    xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-    xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
-    xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
-    xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
-    xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-    xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
-    xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
-    xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
-    xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-    xmlns:xacro="http://www.ros.org/wiki/xacro">
-
-    <xacro:include filename="$(find ada_description)/urdf/kinova_common.xacro" />
-
-
-    <xacro:macro name="kinova_3fingers" params="link_hand prefix">
-
-        <!-- finger1 Rot := Ry(96.12*((1/180)*Pi)) . Rx(1.2*((1/180)*Pi)) . Rz(52.52*((1/180)*Pi)) -->
-        <xacro:kinova_finger prefix="${prefix}" finger_number="1" hand="${link_hand}" finger_origin_xyz="0.00279 0.03126 -0.11467" finger_origin_rpy="-1.7047873384941834 0.6476144647144773 1.67317415161155"/>
-        <!-- finger2 Rot := Ry((1/2)*Pi) . Rx(10.58*((1/180)*Pi)) . Rz(-52.8*((1/180)*Pi)) -->
-        <xacro:kinova_finger prefix="${prefix}" finger_number="2" hand="${link_hand}" finger_origin_xyz="0.02226 -0.02707 -0.11482" finger_origin_rpy="-1.570796327 .649262481663582 -1.38614049188413"/>
-        <!-- finger3 Rot := Ry((1/2)*Pi) . Rx(-10.58*((1/180)*Pi)) . Rz(-52.8*((1/180)*Pi)) -->
-        <xacro:kinova_finger prefix="${prefix}" finger_number="3" hand="${link_hand}" finger_origin_xyz="-0.02226 -0.02707 -0.11482" finger_origin_rpy="-1.570796327 .649262481663582 -1.75545216211587"/>
-
-    </xacro:macro>
-
-
-    <xacro:macro name="kinova_2fingers" params="link_hand prefix">
-
-        <!-- finger1 Rot := Ry((1/2)*Pi) . Rx(Pi) . Rz(-52.8*((1/180)*Pi)) -->
-        <xacro:kinova_finger prefix="${prefix}" finger_number="1" hand="${link_hand}" finger_origin_xyz="-0.0025 0.03095 -0.11482" finger_origin_rpy="-1.570796327 .649262481663582 1.57079632679490"/>
-        <!-- finger2 Rot := Ry((1/2)*Pi) . Rz(-52.8*((1/180)*Pi))  -->
-        <xacro:kinova_finger prefix="${prefix}" finger_number="2" hand="${link_hand}" finger_origin_xyz="-0.0025 -0.03095 -0.11482" finger_origin_rpy="-1.570796327 .649262481663582 -1.57079632679490"/>
-
-    </xacro:macro>
-
-
-
+  <xacro:macro
+    name="kinova_2fingers"
+    params="link_hand prefix"
+  >
+    <!-- finger1 Rot := Ry((1/2)*Pi) . Rx(Pi) . Rz(-52.8*((1/180)*Pi)) -->
+    <xacro:kinova_finger
+      prefix="${prefix}"
+      finger_number="1"
+      hand="${link_hand}"
+      finger_origin_xyz="-0.0025 0.03095 -0.11482"
+      finger_origin_rpy="-1.570796327 .649262481663582 1.57079632679490"
+    />
+    <!-- finger2 Rot := Ry((1/2)*Pi) . Rz(-52.8*((1/180)*Pi))  -->
+    <xacro:kinova_finger
+      prefix="${prefix}"
+      finger_number="2"
+      hand="${link_hand}"
+      finger_origin_xyz="-0.0025 -0.03095 -0.11482"
+      finger_origin_rpy="-1.570796327 .649262481663582 -1.57079632679490"
+    />
+  </xacro:macro>
 </root>

--- a/ada_description/urdf/kinova_inertial.xacro
+++ b/ada_description/urdf/kinova_inertial.xacro
@@ -1,21 +1,20 @@
 <?xml version="1.0"?>
-
-
-<root xmlns:xi="http://www.w3.org/2001/XInclude"
-	xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
-    xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
-	xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-	xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
-    xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
-    xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
-	xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-	xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
-	xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
-    xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
-    xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-	xmlns:xacro="http://www.ros.org/wiki/xacro">
-
-<!-- links      		mesh_no
+<root
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz"
+  xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model"
+  xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+  xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body"
+  xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom"
+  xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint"
+  xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+  xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+  xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
+  xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
+  xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
+  xmlns:xacro="http://www.ros.org/wiki/xacro"
+>
+  <!-- links      		mesh_no
    base           		0
    shoulder       		1
    arm            		2
@@ -33,166 +32,252 @@
    finger_distal      58
 -->
 
-<xacro:macro name="inertia_cylinder" params="mass height radius axis:=0">
+  <xacro:macro
+    name="inertia_cylinder"
+    params="mass height radius axis:=0"
+  >
+    <!-- z Axis -->
+    <xacro:unless value="${axis}">
+      <inertia
+        ixx="${0.083333 * mass * (3*radius*radius + height*height)}"
+        ixy="0"
+        ixz="0"
+        iyy="${0.083333 * mass * (3*radius*radius + height*height)}"
+        iyz="0"
+        izz="${0.5*mass*radius*radius}"
+      />
+    </xacro:unless>
 
-  <!-- z Axis -->
-  <xacro:unless value="${axis}">
-    <inertia  ixx="${0.083333 * mass * (3*radius*radius + height*height)}" ixy="0" ixz="0"
-              iyy="${0.083333 * mass * (3*radius*radius + height*height)}" iyz="0"
-              izz="${0.5*mass*radius*radius}" />
-  </xacro:unless>
+    <!-- y Axis -->
+    <xacro:unless value="${axis-1}">
+      <inertia
+        ixx="${0.083333 * mass * (3*radius*radius + height*height)}"
+        ixy="0"
+        ixz="0"
+        iyy="${0.5*mass*radius*radius}"
+        izz="${0.083333 * mass * (3*radius*radius + height*height)}"
+        iyz="0"
+      />
+    </xacro:unless>
 
-  <!-- y Axis -->
-  <xacro:unless value="${axis-1}">
-   <inertia  ixx="${0.083333 * mass * (3*radius*radius + height*height)}" ixy="0" ixz="0"
-             iyy="${0.5*mass*radius*radius}"
-             izz="${0.083333 * mass * (3*radius*radius + height*height)}" iyz="0" />
-  </xacro:unless>
+    <!-- x Axis -->
+    <xacro:unless value="${axis-2}">
+      <inertia
+        ixx="${0.5*mass*radius*radius}"
+        iyy="${0.083333 * mass * (3*radius*radius + height*height)}"
+        iyz="0"
+        izz="${0.083333 * mass * (3*radius*radius + height*height)}"
+        ixy="0"
+        ixz="0"
+      />
+    </xacro:unless>
+  </xacro:macro>
 
-  <!-- x Axis -->
-  <xacro:unless value="${axis-2}">
-   <inertia  ixx="${0.5*mass*radius*radius}"
-             iyy="${0.083333 * mass * (3*radius*radius + height*height)}" iyz="0"
-             izz="${0.083333 * mass * (3*radius*radius + height*height)}" ixy="0" ixz="0" />
-  </xacro:unless>
-</xacro:macro>
+  <xacro:macro
+    name="kinova_inertial"
+    params="mesh_no"
+  >
+    <!-- base = 0 -->
+    <xacro:unless value="${mesh_no}">
+      <inertial>
+        <mass value="0.46784"/>
+        <origin
+          xyz="0 0 0.1255"
+          rpy="0 0 0"
+        />
+        <xacro:inertia_cylinder
+          height="0.14"
+          radius="0.04"
+          mass="0.46784"
+        />
+      </inertial>
+    </xacro:unless>
 
+    <!-- shoulder = 1 -->
+    <xacro:unless value="${mesh_no-1}">
+      <inertial>
+        <mass value="0.7477"/>
+        <origin xyz="0 -0.002 -0.0605"/>
+        <xacro:inertia_cylinder
+          height="0.14"
+          radius="0.04"
+          mass="0.7477"
+        />
+      </inertial>
+    </xacro:unless>
 
-<xacro:macro name="kinova_inertial" params="mesh_no">
-  <!-- base = 0 -->
-  <xacro:unless value="${mesh_no}">
-    <inertial>
-        <mass value="0.46784" />
-        <origin xyz="0 0 0.1255" rpy="0 0 0"/>
-        <xacro:inertia_cylinder height="0.14"  radius = "0.04" mass="0.46784"/>
-    </inertial>
-  </xacro:unless>
+    <!-- arm = 2-->
+    <xacro:unless value="${mesh_no-2}">
+      <inertial>
+        <mass value="0.99"/>
+        <origin xyz="0 -0.2065 -0.01"/>
+        <xacro:inertia_cylinder
+          height="0.35"
+          radius="0.04"
+          mass="0.99"
+          axis="1"
+        />
+      </inertial>
+    </xacro:unless>
 
-  <!-- shoulder = 1 -->
-  <xacro:unless value="${mesh_no-1}">
-    <inertial>
-        <mass value="0.7477" />
-        <origin xyz="0 -0.002 -0.0605" />
-        <xacro:inertia_cylinder height="0.14"  radius = "0.04" mass="0.7477"/>
-    </inertial>
-  </xacro:unless>
+    <!-- forearm = 3 -->
+    <xacro:unless value="${mesh_no-3}">
+      <inertial>
+        <mass value="0.6763"/>
+        <origin xyz="0 0.081 -0.0086"/>
+        <xacro:inertia_cylinder
+          height="0.15"
+          radius="0.03"
+          mass="0.6763"
+          axis="1"
+        />
+      </inertial>
+    </xacro:unless>
 
-  <!-- arm = 2-->
-  <xacro:unless value="${mesh_no-2}">
-    <inertial>
-        <mass value="0.99" />
-        <origin xyz="0 -0.2065 -0.01" />
-        <xacro:inertia_cylinder height="0.35"  radius = "0.04" mass="0.99" axis="1"/>
-    </inertial>
-  </xacro:unless>
+    <!-- wrist = 4 -->
+    <xacro:unless value="${mesh_no-4}">
+      <inertial>
+        <mass value="0.426367"/>
+        <origin xyz="0 -0.037 -0.0642"/>
+        <xacro:inertia_cylinder
+          height="0.02"
+          radius="0.04"
+          mass="0.1785"
+        />
+      </inertial>
+    </xacro:unless>
 
-  <!-- forearm = 3 -->
-  <xacro:unless value="${mesh_no-3}">
-    <inertial>
-        <mass value="0.6763" />
-        <origin xyz="0 0.081 -0.0086" />
-        <xacro:inertia_cylinder height="0.15"  radius = "0.03" mass="0.6763" axis="1"/>
-    </inertial>
-  </xacro:unless>
-
-  <!-- wrist = 4 -->
-  <xacro:unless value="${mesh_no-4}">
-    <inertial>
-        <mass value="0.426367" />
-        <origin xyz="0 -0.037 -0.0642" />
-        <xacro:inertia_cylinder height="0.02"  radius = "0.04" mass="0.1785"/>
-    </inertial>
-  </xacro:unless>
-
-<!--arm_mico       		5 -->
-  <xacro:unless value="${mesh_no-5}">
-    <inertial>
-        <mass value="0.85968" />
+    <!--arm_mico       		5 -->
+    <xacro:unless value="${mesh_no-5}">
+      <inertial>
+        <mass value="0.85968"/>
         <origin xyz="0 -0.145  -0.0076"/>
-        <xacro:inertia_cylinder height="0.25"  radius = "0.03" mass="0.85968" axis="1"/>
-    </inertial>
-  </xacro:unless>
+        <xacro:inertia_cylinder
+          height="0.25"
+          radius="0.03"
+          mass="0.85968"
+          axis="1"
+        />
+      </inertial>
+    </xacro:unless>
 
-<!--   arm_half1 (7dof)		6 -->
-  <xacro:unless value="${mesh_no-6}">
-    <inertial>
-        <mass value="0.8447" />
-        <origin xyz="0 -0.103563213 0" />
-        <xacro:inertia_cylinder height="0.18"  radius = "0.03" mass="0.8447" axis="1"/>
-    </inertial>
-  </xacro:unless>
+    <!--   arm_half1 (7dof)		6 -->
+    <xacro:unless value="${mesh_no-6}">
+      <inertial>
+        <mass value="0.8447"/>
+        <origin xyz="0 -0.103563213 0"/>
+        <xacro:inertia_cylinder
+          height="0.18"
+          radius="0.03"
+          mass="0.8447"
+          axis="1"
+        />
+      </inertial>
+    </xacro:unless>
 
-<!--   arm_half2 (7dof)		7 -->
-  <xacro:unless value="${mesh_no-7}">
-    <inertial>
-        <mass value="0.8447" />
-        <origin xyz="0 0 -0.1022447445" />
-        <xacro:inertia_cylinder height="0.18"  radius = "0.03" mass="0.8447"/>
-    </inertial>
-  </xacro:unless>
+    <!--   arm_half2 (7dof)		7 -->
+    <xacro:unless value="${mesh_no-7}">
+      <inertial>
+        <mass value="0.8447"/>
+        <origin xyz="0 0 -0.1022447445"/>
+        <xacro:inertia_cylinder
+          height="0.18"
+          radius="0.03"
+          mass="0.8447"
+        />
+      </inertial>
+    </xacro:unless>
 
-<!--   wrist_spherical_1  8 -->
-  <xacro:unless value="${mesh_no-8}">
-    <inertial>
-        <mass value="0.463" />
-        <origin xyz="0 0.0028848942 -0.0541932613" />
-        <xacro:inertia_cylinder height="0.1"  radius = "0.02" mass="0.463"/>
-    </inertial>
-  </xacro:unless>
-<!--   wrist_spherical_2  9 -->
-  <xacro:unless value="${mesh_no-9}">
-    <inertial>
-        <mass value="0.463" />
-        <origin xyz="0 0.0497208855 -0.0028562765" />
-        <xacro:inertia_cylinder height="0.1"  radius = "0.02" mass="0.463" axis="1"/>
-    </inertial>
-  </xacro:unless>
+    <!--   wrist_spherical_1  8 -->
+    <xacro:unless value="${mesh_no-8}">
+      <inertial>
+        <mass value="0.463"/>
+        <origin xyz="0 0.0028848942 -0.0541932613"/>
+        <xacro:inertia_cylinder
+          height="0.1"
+          radius="0.02"
+          mass="0.463"
+        />
+      </inertial>
+    </xacro:unless>
+    <!--   wrist_spherical_2  9 -->
+    <xacro:unless value="${mesh_no-9}">
+      <inertial>
+        <mass value="0.463"/>
+        <origin xyz="0 0.0497208855 -0.0028562765"/>
+        <xacro:inertia_cylinder
+          height="0.1"
+          radius="0.02"
+          mass="0.463"
+          axis="1"
+        />
+      </inertial>
+    </xacro:unless>
 
-<!--   forearm_mico  10 -->
-  <xacro:unless value="${mesh_no-10}">
-    <inertial>
-        <mass value="0.606" />
-        <origin xyz="0 0.0463 -0.0065" />
-        <xacro:inertia_cylinder height="0.08"  radius = "0.02" mass="0.606" axis="1"/>
-    </inertial>
-  </xacro:unless>
+    <!--   forearm_mico  10 -->
+    <xacro:unless value="${mesh_no-10}">
+      <inertial>
+        <mass value="0.606"/>
+        <origin xyz="0 0.0463 -0.0065"/>
+        <xacro:inertia_cylinder
+          height="0.08"
+          radius="0.02"
+          mass="0.606"
+          axis="1"
+        />
+      </inertial>
+    </xacro:unless>
 
-  <!-- hand 3 finger = 55 -->
-  <xacro:unless value="${mesh_no - 55}">
-    <inertial>
-        <mass value="0.99" />
-        <origin xyz="0 0 -0.06" />
-        <xacro:inertia_cylinder height="0.03"  radius = "0.04" mass="0.727"/>
-    </inertial>
-  </xacro:unless>
+    <!-- hand 3 finger = 55 -->
+    <xacro:unless value="${mesh_no - 55}">
+      <inertial>
+        <mass value="0.99"/>
+        <origin xyz="0 0 -0.06"/>
+        <xacro:inertia_cylinder
+          height="0.03"
+          radius="0.04"
+          mass="0.727"
+        />
+      </inertial>
+    </xacro:unless>
 
-  <!-- hand 2 finger = 56 -->
-  <xacro:unless value="${mesh_no - 56}">
-   <inertial>
-        <mass value="0.78" />
-        <origin xyz="0 0 -0.06" />
-        <xacro:inertia_cylinder height="0.03"  radius = "0.04" mass="0.78"/>
-    </inertial>
-  </xacro:unless>
+    <!-- hand 2 finger = 56 -->
+    <xacro:unless value="${mesh_no - 56}">
+      <inertial>
+        <mass value="0.78"/>
+        <origin xyz="0 0 -0.06"/>
+        <xacro:inertia_cylinder
+          height="0.03"
+          radius="0.04"
+          mass="0.78"
+        />
+      </inertial>
+    </xacro:unless>
 
-  <!-- finger_proximal = 57 -->
-  <xacro:unless value="${mesh_no - 57}">
-    <inertial>
-        <mass value="0.01" />
-        <origin xyz="0.022 0 0" />
-        <xacro:inertia_cylinder height="0.03"  radius = "0.004" mass="0.01"/>
-    </inertial>
+    <!-- finger_proximal = 57 -->
+    <xacro:unless value="${mesh_no - 57}">
+      <inertial>
+        <mass value="0.01"/>
+        <origin xyz="0.022 0 0"/>
+        <xacro:inertia_cylinder
+          height="0.03"
+          radius="0.004"
+          mass="0.01"
+        />
+      </inertial>
+    </xacro:unless>
 
-  </xacro:unless>
-
-  <!-- finger_distal = 58 -->
-  <xacro:unless value="${mesh_no - 58}">
-    <inertial>
-        <mass value="0.01" />
-        <origin xyz="0.022 0 0" />
-        <xacro:inertia_cylinder height="0.03"  radius = "0.004" mass="0.01"/>
-    </inertial>
-  </xacro:unless>
-
-</xacro:macro>
+    <!-- finger_distal = 58 -->
+    <xacro:unless value="${mesh_no - 58}">
+      <inertial>
+        <mass value="0.01"/>
+        <origin xyz="0.022 0 0"/>
+        <xacro:inertia_cylinder
+          height="0.03"
+          radius="0.004"
+          mass="0.01"
+        />
+      </inertial>
+    </xacro:unless>
+  </xacro:macro>
 </root>

--- a/ada_hardware/urdf/ada_hardware.ros2_control.xacro
+++ b/ada_hardware/urdf/ada_hardware.ros2_control.xacro
@@ -1,10 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-
-  <xacro:macro name="ada_hardware_interface" params="name prefix:=j2n6s200 sim readonly:=false">
-
-    <ros2_control name="${name}" type="system">
-
+  <xacro:macro
+    name="ada_hardware_interface"
+    params="name prefix:=j2n6s200 sim readonly:=false"
+  >
+    <ros2_control
+      name="${name}"
+      type="system"
+    >
       <hardware>
         <xacro:if value="${sim == 'mock'}">
           <plugin>mock_components/GenericSystem</plugin>
@@ -104,7 +107,5 @@
         <state_interface name="effort"/>
       </joint>
     </ros2_control>
-
   </xacro:macro>
-
 </robot>

--- a/ada_hardware/urdf/ada_hardware.xacro
+++ b/ada_hardware/urdf/ada_hardware.xacro
@@ -1,12 +1,18 @@
 <?xml version="1.0"?>
 <!-- j2n6s200 refers to jaco v2 6DOF non-spherical 2fingers -->
-
-
-<robot xmlns:xi="http://www.w3.org/2001/XInclude"
-	xmlns:xacro="http://www.ros.org/wiki/xacro" name="ada_hardware">
-
-  <xacro:arg name="sim" default="none" />
-  <xacro:arg name="readonly" default="false" />
+<robot
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:xacro="http://www.ros.org/wiki/xacro"
+  name="ada_hardware"
+>
+  <xacro:arg
+    name="sim"
+    default="none"
+  />
+  <xacro:arg
+    name="readonly"
+    default="false"
+  />
 
   <xacro:include filename="$(find ada_description)/urdf/ada.xacro"/>
 
@@ -15,6 +21,6 @@
   <xacro:ada_hardware_interface
     name="Jaco2"
     sim="$(arg sim)"
-    readonly="$(arg readonly)" />
-
+    readonly="$(arg readonly)"
+  />
 </robot>

--- a/ada_moveit/config/ada.ros2_control.xacro
+++ b/ada_moveit/config/ada.ros2_control.xacro
@@ -1,136 +1,144 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-    <xacro:macro name="ada_ros2_control" params="name initial_positions_file sim">
-        <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
+  <xacro:macro
+    name="ada_ros2_control"
+    params="name initial_positions_file sim"
+  >
+    <xacro:property
+      name="initial_positions"
+      value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"
+    />
 
-        <ros2_control name="${name}" type="system">
-            <hardware>
-                <xacro:if value="${sim == 'mock'}">
-                  <plugin>mock_components/GenericSystem</plugin>
-                  <param name="mock_sensor_commands">false</param>
-                  <param name="state_following_offset">0.0</param>
-                </xacro:if>
-                <xacro:if value="${sim == 'isaac'}">
-                  <plugin>ada_hardware/JacoIsaac</plugin>
-                  <param name="namespace">/simulation</param>
-                </xacro:if>
-                <xacro:if value="${sim == 'real'}">
-                  <plugin>ada_hardware/Jaco2</plugin>
-                </xacro:if>
-              </hardware>
-            <joint name="j2n6s200_joint_1">
-                <command_interface name="position"/>
-                <command_interface name="velocity"/>
-                <command_interface name="effort"/>
-                <state_interface name="position">
-                  <param name="initial_value">${initial_positions['j2n6s200_joint_1']}</param>
-                </state_interface>
-                <state_interface name="velocity">
-                    <param name="initial_value">0.0</param>
-                </state_interface>
-                <state_interface name="effort">
-                    <param name="initial_value">0.0</param>
-                </state_interface>
-            </joint>
-            <joint name="j2n6s200_joint_2">
-                <command_interface name="position"/>
-                <command_interface name="velocity"/>
-                <command_interface name="effort"/>
-                <state_interface name="position">
-                  <param name="initial_value">${initial_positions['j2n6s200_joint_2']}</param>
-                </state_interface>
-                <state_interface name="velocity">
-                    <param name="initial_value">0.0</param>
-                </state_interface>
-                <state_interface name="effort">
-                    <param name="initial_value">0.0</param>
-                </state_interface>
-            </joint>
-            <joint name="j2n6s200_joint_3">
-                <command_interface name="position"/>
-                <command_interface name="velocity"/>
-                <command_interface name="effort"/>
-                <state_interface name="position">
-                  <param name="initial_value">${initial_positions['j2n6s200_joint_3']}</param>
-                </state_interface>
-                <state_interface name="velocity">
-                    <param name="initial_value">0.0</param>
-                </state_interface>
-                <state_interface name="effort">
-                    <param name="initial_value">0.0</param>
-                </state_interface>
-            </joint>
-            <joint name="j2n6s200_joint_4">
-                <command_interface name="position"/>
-                <command_interface name="velocity"/>
-                <command_interface name="effort"/>
-                <state_interface name="position">
-                  <param name="initial_value">${initial_positions['j2n6s200_joint_4']}</param>
-                </state_interface>
-                <state_interface name="velocity">
-                    <param name="initial_value">0.0</param>
-                </state_interface>
-                <state_interface name="effort">
-                    <param name="initial_value">0.0</param>
-                </state_interface>
-            </joint>
-            <joint name="j2n6s200_joint_5">
-                <command_interface name="position"/>
-                <command_interface name="velocity"/>
-                <command_interface name="effort"/>
-                <state_interface name="position">
-                  <param name="initial_value">${initial_positions['j2n6s200_joint_5']}</param>
-                </state_interface>
-                <state_interface name="velocity">
-                    <param name="initial_value">0.0</param>
-                </state_interface>
-                <state_interface name="effort">
-                    <param name="initial_value">0.0</param>
-                </state_interface>
-            </joint>
-            <joint name="j2n6s200_joint_6">
-                <command_interface name="position"/>
-                <command_interface name="velocity"/>
-                <command_interface name="effort"/>
-                <state_interface name="position">
-                  <param name="initial_value">${initial_positions['j2n6s200_joint_6']}</param>
-                </state_interface>
-                <state_interface name="velocity">
-                    <param name="initial_value">0.0</param>
-                </state_interface>
-                <state_interface name="effort">
-                    <param name="initial_value">0.0</param>
-                </state_interface>
-            </joint>
-            <joint name="j2n6s200_joint_finger_1">
-                <command_interface name="position"/>
-                <command_interface name="velocity"/>
-                <command_interface name="effort"/>
-                <state_interface name="position">
-                  <param name="initial_value">${initial_positions['j2n6s200_joint_finger_1']}</param>
-                </state_interface>
-                <state_interface name="velocity">
-                    <param name="initial_value">0.0</param>
-                </state_interface>
-                <state_interface name="effort">
-                    <param name="initial_value">0.0</param>
-                </state_interface>
-            </joint>
-            <joint name="j2n6s200_joint_finger_2">
-                <command_interface name="position"/>
-                <command_interface name="velocity"/>
-                <command_interface name="effort"/>
-                <state_interface name="position">
-                  <param name="initial_value">${initial_positions['j2n6s200_joint_finger_2']}</param>
-                </state_interface>
-                <state_interface name="velocity">
-                    <param name="initial_value">0.0</param>
-                </state_interface>
-                <state_interface name="effort">
-                    <param name="initial_value">0.0</param>
-                </state_interface>
-            </joint>
-
-        </ros2_control>
-    </xacro:macro>
+    <ros2_control
+      name="${name}"
+      type="system"
+    >
+      <hardware>
+        <xacro:if value="${sim == 'mock'}">
+          <plugin>mock_components/GenericSystem</plugin>
+          <param name="mock_sensor_commands">false</param>
+          <param name="state_following_offset">0.0</param>
+        </xacro:if>
+        <xacro:if value="${sim == 'isaac'}">
+          <plugin>ada_hardware/JacoIsaac</plugin>
+          <param name="namespace">/simulation</param>
+        </xacro:if>
+        <xacro:if value="${sim == 'real'}">
+          <plugin>ada_hardware/Jaco2</plugin>
+        </xacro:if>
+      </hardware>
+      <joint name="j2n6s200_joint_1">
+        <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
+        <state_interface name="position">
+          <param name="initial_value">${initial_positions['j2n6s200_joint_1']}</param>
+        </state_interface>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+      </joint>
+      <joint name="j2n6s200_joint_2">
+        <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
+        <state_interface name="position">
+          <param name="initial_value">${initial_positions['j2n6s200_joint_2']}</param>
+        </state_interface>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+      </joint>
+      <joint name="j2n6s200_joint_3">
+        <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
+        <state_interface name="position">
+          <param name="initial_value">${initial_positions['j2n6s200_joint_3']}</param>
+        </state_interface>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+      </joint>
+      <joint name="j2n6s200_joint_4">
+        <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
+        <state_interface name="position">
+          <param name="initial_value">${initial_positions['j2n6s200_joint_4']}</param>
+        </state_interface>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+      </joint>
+      <joint name="j2n6s200_joint_5">
+        <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
+        <state_interface name="position">
+          <param name="initial_value">${initial_positions['j2n6s200_joint_5']}</param>
+        </state_interface>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+      </joint>
+      <joint name="j2n6s200_joint_6">
+        <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
+        <state_interface name="position">
+          <param name="initial_value">${initial_positions['j2n6s200_joint_6']}</param>
+        </state_interface>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+      </joint>
+      <joint name="j2n6s200_joint_finger_1">
+        <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
+        <state_interface name="position">
+          <param name="initial_value">${initial_positions['j2n6s200_joint_finger_1']}</param>
+        </state_interface>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+      </joint>
+      <joint name="j2n6s200_joint_finger_2">
+        <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <command_interface name="effort"/>
+        <state_interface name="position">
+          <param name="initial_value">${initial_positions['j2n6s200_joint_finger_2']}</param>
+        </state_interface>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+      </joint>
+    </ros2_control>
+  </xacro:macro>
 </robot>

--- a/ada_moveit/config/ada.urdf.xacro
+++ b/ada_moveit/config/ada.urdf.xacro
@@ -1,17 +1,26 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="ada">
-    <xacro:arg name="initial_positions_file" default="initial_positions.yaml" />
-    <xacro:arg name="sim" default="real" />
+<robot
+  xmlns:xacro="http://www.ros.org/wiki/xacro"
+  name="ada"
+>
+  <xacro:arg
+    name="initial_positions_file"
+    default="initial_positions.yaml"
+  />
+  <xacro:arg
+    name="sim"
+    default="real"
+  />
 
-    <!-- Import ada urdf file -->
-    <xacro:include filename="$(find ada_description)/urdf/ada.xacro" />
+  <!-- Import ada urdf file -->
+  <xacro:include filename="$(find ada_description)/urdf/ada.xacro"/>
 
-    <!-- Import control_xacro -->
-    <xacro:include filename="ada.ros2_control.xacro" />
+  <!-- Import control_xacro -->
+  <xacro:include filename="ada.ros2_control.xacro"/>
 
-
-    <xacro:ada_ros2_control name="ADAHardware"
-        initial_positions_file="$(arg initial_positions_file)"
-        sim="$(arg sim)" />
-
+  <xacro:ada_ros2_control
+    name="ADAHardware"
+    initial_positions_file="$(arg initial_positions_file)"
+    sim="$(arg sim)"
+  />
 </robot>

--- a/ada_moveit/package.xml
+++ b/ada_moveit/package.xml
@@ -3,9 +3,7 @@
 <package format="3">
   <name>ada_moveit</name>
   <version>0.3.0</version>
-  <description>
-     An automatically generated package with all the configuration and launch files for using the ada with the MoveIt Motion Planning Framework
-  </description>
+  <description>An automatically generated package with all the configuration and launch files for using the ada with the MoveIt Motion Planning Framework</description>
   <maintainer email="ekgordon@cs.uw.edu">Ethan K. Gordon</maintainer>
 
   <license>BSD</license>
@@ -50,8 +48,7 @@
   <!-- <exec_depend>joint_trajectory_controller</exec_depend> -->
   <!-- <exec_depend>gazebo_ros_control</exec_depend> -->
 
-
   <export>
-      <build_type>ament_cmake</build_type>
+    <build_type>ament_cmake</build_type>
   </export>
 </package>


### PR DESCRIPTION
# Description

This PR adds a pre-commit routine for [prettier](https://github.com/prettier/plugin-xml/) formatting on Xacro, launch and package XML files. Resolves #56 

You must run `npm install --save-dev prettier @prettier/plugin-xml` prior to `pre-commit run --all-files` to run prettier with the XML plugin.

Note to reviewers: You don't need to read all the thousands of changed lines, just skim through and notice that our Xacro is actually readable now :)

# Testing procedure

This PR does not introduce any fundamental changes to the behavior of the code, it just updates formatting 

# Before opening a pull request

- \[x\] `pre-commit run --all-files`
- \[x\] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/). `pylint --recursive=y --rcfile=.pylintrc .`. All warnings but `fixme` must be addressed.

# Before Merging

- \[ \] `Squash & Merge`
